### PR TITLE
Add QR & PDF tools + shadcn-svelte UI with dark mode and tools menu

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://shadcn-svelte.com/schema.json",
+	"tailwind": {
+		"css": "src/lib/styles/app.css",
+		"baseColor": "neutral"
+	},
+	"aliases": {
+		"components": "$lib/components",
+		"utils": "$lib/utils",
+		"ui": "$lib/components/ui",
+		"hooks": "$lib/hooks",
+		"lib": "$lib"
+	},
+	"typescript": true,
+	"registry": "https://shadcn-svelte.com/registry"
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tools",
 	"type": "module",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"private": true,
 	"engines": {
 		"node": "^24.0.0 || >=25.0.0"
@@ -17,11 +17,18 @@
 		"lint:fix": "eslint --fix"
 	},
 	"dependencies": {
+		"@lucide/svelte": "^1.22.0",
 		"@tensorflow-models/face-detection": "^1.0.3",
 		"@tensorflow/tfjs-backend-webgl": "^4.22.0",
 		"@tensorflow/tfjs-core": "^4.22.0",
+		"bits-ui": "^2.18.1",
+		"clsx": "^2.1.1",
 		"jszip": "^3.10.1",
-		"pdf-lib": "^1.17.1"
+		"mode-watcher": "^1.1.0",
+		"pdf-lib": "^1.17.1",
+		"qr-code-styling": "^1.9.2",
+		"tailwind-merge": "^3.6.0",
+		"tailwind-variants": "^3.2.2"
 	},
 	"devDependencies": {
 		"@antfu/eslint-config": "^9.0.0",
@@ -29,12 +36,15 @@
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.67.0",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",
+		"@tailwindcss/vite": "^4.3.2",
 		"eslint": "^10.5.0",
 		"eslint-plugin-format": "^2.0.1",
 		"eslint-plugin-svelte": "^3.17.1",
 		"svelte": "^5.56.4",
 		"svelte-check": "^4.7.0",
 		"svelte-eslint-parser": "^1.8.0",
+		"tailwindcss": "^4.3.2",
+		"tw-animate-css": "^1.4.0",
 		"typescript": "^6.0.3",
 		"vite": "^8.1.0"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   .:
     dependencies:
+      '@lucide/svelte':
+        specifier: ^1.22.0
+        version: 1.22.0(svelte@5.56.4(@typescript-eslint/types@8.60.0))
       '@tensorflow-models/face-detection':
         specifier: ^1.0.3
         version: 1.0.3(@mediapipe/face_detection@0.4.1646425229)(@tensorflow/tfjs-backend-webgl@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)
@@ -23,37 +26,58 @@ importers:
       '@tensorflow/tfjs-core':
         specifier: ^4.22.0
         version: 4.22.0
+      bits-ui:
+        specifier: ^2.18.1
+        version: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
+      mode-watcher:
+        specifier: ^1.1.0
+        version: 1.1.0(svelte@5.56.4(@typescript-eslint/types@8.60.0))
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
+      qr-code-styling:
+        specifier: ^1.9.2
+        version: 1.9.2
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
+      tailwind-variants:
+        specifier: ^3.2.2
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^9.0.0
-        version: 9.0.0(@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3))(@typescript-eslint/utils@8.60.0(eslint@10.5.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint-plugin-format@2.0.1(eslint@10.5.0))(eslint-plugin-svelte@3.19.0(eslint@10.5.0)(svelte@5.56.4(@typescript-eslint/types@8.60.0)))(eslint@10.5.0)(svelte-eslint-parser@1.8.0(svelte@5.56.4(@typescript-eslint/types@8.60.0)))(typescript@6.0.3)
+        version: 9.0.0(@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3))(@typescript-eslint/utils@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint-plugin-format@2.0.1(eslint@10.5.0(jiti@2.7.0)))(eslint-plugin-svelte@3.19.0(eslint@10.5.0(jiti@2.7.0))(svelte@5.56.4(@typescript-eslint/types@8.60.0)))(eslint@10.5.0(jiti@2.7.0))(svelte-eslint-parser@1.8.0(svelte@5.56.4(@typescript-eslint/types@8.60.0)))(typescript@6.0.3)
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))
+        version: 7.0.1(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))
+        version: 3.0.10(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: ^2.67.0
-        version: 2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0))
+        version: 2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0))
+        version: 7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      '@tailwindcss/vite':
+        specifier: ^4.3.2
+        version: 4.3.2(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       eslint:
         specifier: ^10.5.0
-        version: 10.5.0
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-format:
         specifier: ^2.0.1
-        version: 2.0.1(eslint@10.5.0)
+        version: 2.0.1(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-svelte:
         specifier: ^3.17.1
-        version: 3.19.0(eslint@10.5.0)(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+        version: 3.19.0(eslint@10.5.0(jiti@2.7.0))(svelte@5.56.4(@typescript-eslint/types@8.60.0))
       svelte:
         specifier: ^5.56.4
         version: 5.56.4(@typescript-eslint/types@8.60.0)
@@ -63,12 +87,18 @@ importers:
       svelte-eslint-parser:
         specifier: ^1.8.0
         version: 1.8.0(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+      tailwindcss:
+        specifier: ^4.3.2
+        version: 4.3.2
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.1.0
-        version: 8.1.0(esbuild@0.27.7)(yaml@2.9.0)
+        version: 8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
 
 packages:
 
@@ -411,6 +441,15 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -431,6 +470,9 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -446,6 +488,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lucide/svelte@1.22.0':
+    resolution: {integrity: sha512-eaNC3GGu9ma7mviB9vPL6OnawXqxdvRnoAQSq5l15mBlsuwD7kozZ7pzPXSlT6OwSl7hz4qTk+ZU3OEewwi5gQ==}
+    peerDependencies:
+      svelte: ^5
 
   '@mediapipe/face_detection@0.4.1646425229':
     resolution: {integrity: sha512-aeCN+fRAojv9ch3NXorP6r5tcGVLR3/gC1HmtqB0WEZBRXrdP6/3W/sGR0dHr1iT6ueiK95G9PVjbzFosf/hrg==}
@@ -510,48 +557,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.35.0':
     resolution: {integrity: sha512-5Okqi+uhYFxwKz8hcnUftNNwdm8BCkf6GSCbcz9xJxYMm87k1E4p7PEmAAbhLTk7cjSdDre6TDL0pDzNX+Y22Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.35.0':
     resolution: {integrity: sha512-9k66pbZQXM/lBJWys3Xbc5yhl4JexyfqkEf/tvtq8976VIJnLAAL3M127xHA3ifYSqxdVHfVGTg84eiBHCGcNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.35.0':
     resolution: {integrity: sha512-aUcY9ofKPtjO52idT6t0SAQvEF6ctjzUQa1lLp7GDsRpSBvuTrBQGeq0rYKz3gN8dMIQ7mtMdGD9tT4LhR8jAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.35.0':
     resolution: {integrity: sha512-C6yhY5Hvc2sGM+mCPek9ZLe5xRUOC/BvhAt2qIWFAeXMn4il04EYIjl3DsWiJr0xDMTJhvMOmD55xTRPlNp39w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.35.0':
     resolution: {integrity: sha512-RG2hlvOMK4OMZpO3mt8MpxLQ0AAezlFqhn5mI/g5YrVbPFyoCv9a34AAvbSJS501ocOxlFIRcKEuw5hFvddf9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.35.0':
     resolution: {integrity: sha512-wzmh90Pwvqj9xOKHJjkQYBpydRkaXG77ZvDz+iFDRRQpnqIEqGm5gmim2s6vnZIkDGsvKCuTdtxm0GFmBjM1+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.35.0':
     resolution: {integrity: sha512-+HCqYCJPCUy5I+b2cf+gUVaApfgtoQT3HdnSg/l7NIcLHOhKstlYaGyrFZLmUpQt4WkFbpGKZZayG6zjRU0KFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.35.0':
     resolution: {integrity: sha512-kFYmWfR9YL78XyO5ws+1dsxNvZoD973qfVMNFOS4e9bcHXGF7DvGC2tY5UDFwyMCeB33t3sDIuGONKggnVNSJA==}
@@ -625,36 +680,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.3':
     resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.3':
     resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.3':
     resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.3':
     resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.3':
     resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.3':
     resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
@@ -736,6 +797,103 @@ packages:
     peerDependencies:
       svelte: ^5.46.4
       vite: ^8.0.0-beta.7 || ^8.0.0
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@tailwindcss/node@4.3.2':
+    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.2':
+    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.2':
+    resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@tensorflow-models/face-detection@1.0.3':
     resolution: {integrity: sha512-4Ld/vFF8MrdFdrMWhlLKZD4hMW0PNY9OkYeqoCPNZ+LwFyenxAqVaNaWrR8JKp37vw9Nuzp4ILbkal5zPUnA0g==}
@@ -955,6 +1113,13 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bits-ui@2.18.1:
+    resolution: {integrity: sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@internationalized/date': ^3.8.1
+      svelte: ^5.33.0
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1093,6 +1258,10 @@ packages:
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
+
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
 
   enhanced-resolve@5.22.1:
     resolution: {integrity: sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==}
@@ -1490,6 +1659,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   is-builtin-module@5.0.0:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
     engines: {node: '>=18.20'}
@@ -1510,6 +1682,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
 
   jsdoc-type-pratt-parser@7.1.1:
     resolution: {integrity: sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==}
@@ -1596,24 +1772,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1654,6 +1834,10 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1799,6 +1983,11 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  mode-watcher@1.1.0:
+    resolution: {integrity: sha512-mUT9RRGPDYenk59qJauN1rhsIMKBmWA3xMF+uRwE8MW/tjhaDSCCARqkSuDTq8vr4/2KcAxIGVjACxTjdk5C3g==}
+    peerDependencies:
+      svelte: ^5.27.0
 
   module-replacements@3.0.0-beta.7:
     resolution: {integrity: sha512-n1F9l3gF1wNh13xmnXS2JU7P9c3DlzCgVEyLKrVN0U37RwrXyYoePMMvYvs/6aUONAxbnscphzESZTCorXFh7Q==}
@@ -1986,6 +2175,13 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qr-code-styling@1.9.2:
+    resolution: {integrity: sha512-RgJaZJ1/RrXJ6N0j7a+pdw3zMBmzZU4VN2dtAZf8ZggCfRB5stEQ3IoDNGaNhYY3nnZKYlYSLl5YkfWN5dPutg==}
+    engines: {node: '>=18.18.0'}
+
+  qrcode-generator@1.5.2:
+    resolution: {integrity: sha512-pItrW0Z9HnDBnFmgiNrY1uxRdri32Uh9EjNYLPVC2zZ3ZRIIEqBoDgm4DkvDwNNDHTK7FNkmr8zAa77BYc9xNw==}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -2028,6 +2224,25 @@ packages:
     resolution: {integrity: sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  runed@0.23.4:
+    resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
+    peerDependencies:
+      svelte: ^5.7.0
+
+  runed@0.25.0:
+    resolution: {integrity: sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg==}
+    peerDependencies:
+      svelte: ^5.7.0
+
+  runed@0.35.1:
+    resolution: {integrity: sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.21.0
+      svelte: ^5.7.0
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
 
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -2094,6 +2309,9 @@ packages:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
 
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
   svelte-check@4.7.0:
     resolution: {integrity: sha512-XChCqdDg29UWOWai2I1s2Ss003piZ9mae2y2KXwoOX01W75mg7/fwLLnx9Yruk9asHkxHPDdSfEfsJh5tr9JvQ==}
     engines: {node: '>= 18.0.0'}
@@ -2111,6 +2329,18 @@ packages:
       svelte:
         optional: true
 
+  svelte-toolbelt@0.10.6:
+    resolution: {integrity: sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.30.2
+
+  svelte-toolbelt@0.7.1:
+    resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.0.0
+
   svelte@5.56.4:
     resolution: {integrity: sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==}
     engines: {node: '>=18'}
@@ -2118,6 +2348,25 @@ packages:
   synckit@0.11.13:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwind-variants@3.2.2:
+    resolution: {integrity: sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwind-merge: '>=3.0.0'
+      tailwindcss: '*'
+    peerDependenciesMeta:
+      tailwind-merge:
+        optional: true
+
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -2164,6 +2413,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2308,48 +2560,48 @@ packages:
 
 snapshots:
 
-  '@antfu/eslint-config@9.0.0(@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3))(@typescript-eslint/utils@8.60.0(eslint@10.5.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint-plugin-format@2.0.1(eslint@10.5.0))(eslint-plugin-svelte@3.19.0(eslint@10.5.0)(svelte@5.56.4(@typescript-eslint/types@8.60.0)))(eslint@10.5.0)(svelte-eslint-parser@1.8.0(svelte@5.56.4(@typescript-eslint/types@8.60.0)))(typescript@6.0.3)':
+  '@antfu/eslint-config@9.0.0(@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3))(@typescript-eslint/utils@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint-plugin-format@2.0.1(eslint@10.5.0(jiti@2.7.0)))(eslint-plugin-svelte@3.19.0(eslint@10.5.0(jiti@2.7.0))(svelte@5.56.4(@typescript-eslint/types@8.60.0)))(eslint@10.5.0(jiti@2.7.0))(svelte-eslint-parser@1.8.0(svelte@5.56.4(@typescript-eslint/types@8.60.0)))(typescript@6.0.3)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.5.0
-      '@e18e/eslint-plugin': 0.4.1(eslint@10.5.0)
-      '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@10.5.0)
+      '@e18e/eslint-plugin': 0.4.1(eslint@10.5.0(jiti@2.7.0))
+      '@eslint-community/eslint-plugin-eslint-comments': 4.7.2(eslint@10.5.0(jiti@2.7.0))
       '@eslint/markdown': 8.0.2
-      '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
-      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
-      '@vitest/eslint-plugin': 1.6.18(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0(jiti@2.7.0))
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@vitest/eslint-plugin': 1.6.18(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       ansis: 4.3.0
       cac: 7.0.0
-      eslint: 10.5.0
-      eslint-config-flat-gitignore: 2.3.0(eslint@10.5.0)
+      eslint: 10.5.0(jiti@2.7.0)
+      eslint-config-flat-gitignore: 2.3.0(eslint@10.5.0(jiti@2.7.0))
       eslint-flat-config-utils: 3.2.0
-      eslint-merge-processors: 2.0.0(eslint@10.5.0)
-      eslint-plugin-antfu: 3.2.3(eslint@10.5.0)
-      eslint-plugin-command: 3.5.2(@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3))(@typescript-eslint/utils@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)
-      eslint-plugin-import-lite: 0.6.0(eslint@10.5.0)
-      eslint-plugin-jsdoc: 62.9.0(eslint@10.5.0)
-      eslint-plugin-jsonc: 3.2.0(eslint@10.5.0)
-      eslint-plugin-n: 18.0.1(eslint@10.5.0)(typescript@6.0.3)
+      eslint-merge-processors: 2.0.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-antfu: 3.2.3(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-command: 3.5.2(@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3))(@typescript-eslint/utils@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-import-lite: 0.6.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-jsdoc: 62.9.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-jsonc: 3.2.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-n: 18.0.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-no-only-tests: 3.4.0
-      eslint-plugin-perfectionist: 5.9.0(eslint@10.5.0)(typescript@6.0.3)
-      eslint-plugin-pnpm: 1.6.1(eslint@10.5.0)
-      eslint-plugin-regexp: 3.1.0(eslint@10.5.0)
-      eslint-plugin-toml: 1.4.0(eslint@10.5.0)
-      eslint-plugin-unicorn: 64.0.0(eslint@10.5.0)
-      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)
-      eslint-plugin-vue: 10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(vue-eslint-parser@10.4.0(eslint@10.5.0))
-      eslint-plugin-yml: 3.4.0(eslint@10.5.0)
-      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.35)(eslint@10.5.0)
+      eslint-plugin-perfectionist: 5.9.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint-plugin-pnpm: 1.6.1(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-regexp: 3.1.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-toml: 1.4.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-unicorn: 64.0.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-unused-imports: 4.4.1(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-vue: 10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0)))(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@10.5.0(jiti@2.7.0)))
+      eslint-plugin-yml: 3.4.0(eslint@10.5.0(jiti@2.7.0))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.35)(eslint@10.5.0(jiti@2.7.0))
       globals: 17.6.0
       local-pkg: 1.2.1
       parse-gitignore: 2.0.0
       toml-eslint-parser: 1.0.3
-      vue-eslint-parser: 10.4.0(eslint@10.5.0)
+      vue-eslint-parser: 10.4.0(eslint@10.5.0(jiti@2.7.0))
       yaml-eslint-parser: 2.0.0
     optionalDependencies:
-      eslint-plugin-format: 2.0.1(eslint@10.5.0)
-      eslint-plugin-svelte: 3.19.0(eslint@10.5.0)(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+      eslint-plugin-format: 2.0.1(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-svelte: 3.19.0(eslint@10.5.0(jiti@2.7.0))(svelte@5.56.4(@typescript-eslint/types@8.60.0))
       svelte-eslint-parser: 1.8.0(svelte@5.56.4(@typescript-eslint/types@8.60.0))
     transitivePeerDependencies:
       - '@eslint/json'
@@ -2399,13 +2651,13 @@ snapshots:
 
   '@dprint/toml@0.7.0': {}
 
-  '@e18e/eslint-plugin@0.4.1(eslint@10.5.0)':
+  '@e18e/eslint-plugin@0.4.1(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
       empathic: 2.0.1
       module-replacements: 3.0.0-beta.7
       semver: 7.8.5
     optionalDependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -2519,24 +2771,24 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.7.2(eslint@10.5.0)':
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.2(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       ignore: 7.0.5
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.1.0(eslint@10.5.0)':
+  '@eslint/compat@2.1.0(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
       '@eslint/core': 1.2.1
     optionalDependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
 
   '@eslint/config-array@0.23.5':
     dependencies:
@@ -2581,6 +2833,17 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2596,6 +2859,10 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@internationalized/date@3.12.2':
+    dependencies:
+      '@swc/helpers': 0.5.23
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2615,6 +2882,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lucide/svelte@1.22.0(svelte@5.56.4(@typescript-eslint/types@8.60.0))':
+    dependencies:
+      svelte: 5.56.4(@typescript-eslint/types@8.60.0)
 
   '@mediapipe/face_detection@0.4.1646425229': {}
 
@@ -2753,11 +3024,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stylistic/eslint-plugin@5.10.0(eslint@10.5.0)':
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@typescript-eslint/types': 8.60.0
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -2767,19 +3038,19 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))':
     dependencies:
-      '@sveltejs/kit': 2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0))
+      '@sveltejs/kit': 2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))':
     dependencies:
-      '@sveltejs/kit': 2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0))
+      '@sveltejs/kit': 2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
 
-  '@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0))':
+  '@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.17.0
       cookie: 0.7.0
@@ -2791,20 +3062,92 @@ snapshots:
       set-cookie-parser: 3.1.1
       sirv: 3.0.2
       svelte: 5.56.4(@typescript-eslint/types@8.60.0)
-      vite: 8.1.0(esbuild@0.27.7)(yaml@2.9.0)
+      vite: 8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
       typescript: 6.0.3
 
   '@sveltejs/load-config@0.2.0': {}
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.56.4(@typescript-eslint/types@8.60.0)
-      vite: 8.1.0(esbuild@0.27.7)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0))
+      vite: 8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tailwindcss/node@4.3.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.2
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-x64': 4.3.2
+      '@tailwindcss/oxide-freebsd-x64': 4.3.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
+
+  '@tailwindcss/vite@4.3.2(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
+      tailwindcss: 4.3.2
+      vite: 8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
 
   '@tensorflow-models/face-detection@1.0.3(@mediapipe/face_detection@0.4.1646425229)(@tensorflow/tfjs-backend-webgl@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)':
     dependencies:
@@ -2886,15 +3229,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.60.0
-      '@typescript-eslint/type-utils': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.60.0
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -2902,14 +3245,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.0
       '@typescript-eslint/types': 8.60.0
       '@typescript-eslint/typescript-estree': 8.60.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -2923,13 +3266,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0)(typescript@6.0.3)':
+  '@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.60.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       ajv: 6.15.0
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
       semver: 7.8.5
@@ -2946,13 +3289,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.60.0(eslint@10.5.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.60.0
       '@typescript-eslint/typescript-estree': 8.60.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -2975,13 +3318,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.60.0(eslint@10.5.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.60.0
       '@typescript-eslint/types': 8.60.0
       '@typescript-eslint/typescript-estree': 8.60.0(typescript@6.0.3)
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -2991,13 +3334,13 @@ snapshots:
       '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/eslint-plugin@1.6.18(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)':
+  '@vitest/eslint-plugin@1.6.18(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.0
-      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
-      eslint: 10.5.0
+      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3062,6 +3405,19 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.33: {}
+
+  bits-ui@2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0)):
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/dom': 1.7.6
+      '@internationalized/date': 3.12.2
+      esm-env: 1.2.2
+      runed: 0.35.1(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+      svelte: 5.56.4(@typescript-eslint/types@8.60.0)
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+      tabbable: 6.5.0
+    transitivePeerDependencies:
+      - '@sveltejs/kit'
 
   boolbase@1.0.0: {}
 
@@ -3164,6 +3520,11 @@ snapshots:
 
   empathic@2.0.1: {}
 
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   enhanced-resolve@5.22.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -3209,75 +3570,75 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@10.5.0):
+  eslint-compat-utils@0.5.1(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       semver: 7.8.5
 
-  eslint-config-flat-gitignore@2.3.0(eslint@10.5.0):
+  eslint-config-flat-gitignore@2.3.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      '@eslint/compat': 2.1.0(eslint@10.5.0)
-      eslint: 10.5.0
+      '@eslint/compat': 2.1.0(eslint@10.5.0(jiti@2.7.0))
+      eslint: 10.5.0(jiti@2.7.0)
 
   eslint-flat-config-utils@3.2.0:
     dependencies:
       '@eslint/config-helpers': 0.5.5
       pathe: 2.0.3
 
-  eslint-formatting-reporter@0.0.0(eslint@10.5.0):
+  eslint-formatting-reporter@0.0.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       prettier-linter-helpers: 1.0.1
 
-  eslint-json-compat-utils@0.2.3(eslint@10.5.0)(jsonc-eslint-parser@3.1.0):
+  eslint-json-compat-utils@0.2.3(eslint@10.5.0(jiti@2.7.0))(jsonc-eslint-parser@3.1.0):
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       esquery: 1.7.0
       jsonc-eslint-parser: 3.1.0
 
-  eslint-merge-processors@2.0.0(eslint@10.5.0):
+  eslint-merge-processors@2.0.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
 
   eslint-parser-plain@0.1.1: {}
 
-  eslint-plugin-antfu@3.2.3(eslint@10.5.0):
+  eslint-plugin-antfu@3.2.3(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
 
-  eslint-plugin-command@3.5.2(@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0)(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3))(@typescript-eslint/utils@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0):
+  eslint-plugin-command@3.5.2(@typescript-eslint/rule-tester@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3))(@typescript-eslint/utils@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@es-joy/jsdoccomment': 0.84.0
-      '@typescript-eslint/rule-tester': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/rule-tester': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.60.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
-      eslint: 10.5.0
+      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
 
-  eslint-plugin-es-x@7.8.0(eslint@10.5.0):
+  eslint-plugin-es-x@7.8.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      eslint: 10.5.0
-      eslint-compat-utils: 0.5.1(eslint@10.5.0)
+      eslint: 10.5.0(jiti@2.7.0)
+      eslint-compat-utils: 0.5.1(eslint@10.5.0(jiti@2.7.0))
 
-  eslint-plugin-format@2.0.1(eslint@10.5.0):
+  eslint-plugin-format@2.0.1(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@dprint/formatter': 0.5.1
       '@dprint/markdown': 0.21.1
       '@dprint/toml': 0.7.0
-      eslint: 10.5.0
-      eslint-formatting-reporter: 0.0.0(eslint@10.5.0)
+      eslint: 10.5.0(jiti@2.7.0)
+      eslint-formatting-reporter: 0.0.0(eslint@10.5.0(jiti@2.7.0))
       eslint-parser-plain: 0.1.1
       ohash: 2.0.11
       oxfmt: 0.35.0
       prettier: 3.8.3
       synckit: 0.11.13
 
-  eslint-plugin-import-lite@0.6.0(eslint@10.5.0):
+  eslint-plugin-import-lite@0.6.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
 
-  eslint-plugin-jsdoc@62.9.0(eslint@10.5.0):
+  eslint-plugin-jsdoc@62.9.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@es-joy/jsdoccomment': 0.86.0
       '@es-joy/resolve.exports': 1.2.0
@@ -3285,7 +3646,7 @@ snapshots:
       comment-parser: 1.4.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       espree: 11.2.0
       esquery: 1.7.0
       html-entities: 2.6.0
@@ -3297,27 +3658,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsonc@3.2.0(eslint@10.5.0):
+  eslint-plugin-jsonc@3.2.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@ota-meshi/ast-token-store': 0.3.0
       diff-sequences: 29.6.3
-      eslint: 10.5.0
-      eslint-json-compat-utils: 0.2.3(eslint@10.5.0)(jsonc-eslint-parser@3.1.0)
+      eslint: 10.5.0(jiti@2.7.0)
+      eslint-json-compat-utils: 0.2.3(eslint@10.5.0(jiti@2.7.0))(jsonc-eslint-parser@3.1.0)
       jsonc-eslint-parser: 3.1.0
       natural-compare: 1.4.0
       synckit: 0.11.13
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-n@18.0.1(eslint@10.5.0)(typescript@6.0.3):
+  eslint-plugin-n@18.0.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       enhanced-resolve: 5.22.1
-      eslint: 10.5.0
-      eslint-plugin-es-x: 7.8.0(eslint@10.5.0)
+      eslint: 10.5.0(jiti@2.7.0)
+      eslint-plugin-es-x: 7.8.0(eslint@10.5.0(jiti@2.7.0))
       get-tsconfig: 4.14.0
       globals: 15.15.0
       globrex: 0.1.2
@@ -3328,19 +3689,19 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.4.0: {}
 
-  eslint-plugin-perfectionist@5.9.0(eslint@10.5.0)(typescript@6.0.3):
+  eslint-plugin-perfectionist@5.9.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
-      eslint: 10.5.0
+      '@typescript-eslint/utils': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-pnpm@1.6.1(eslint@10.5.0):
+  eslint-plugin-pnpm@1.6.1(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       empathic: 2.0.1
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       jsonc-eslint-parser: 3.1.0
       pathe: 2.0.3
       pnpm-workspace-yaml: 1.6.1
@@ -3348,22 +3709,22 @@ snapshots:
       yaml: 2.9.0
       yaml-eslint-parser: 2.0.0
 
-  eslint-plugin-regexp@3.1.0(eslint@10.5.0):
+  eslint-plugin-regexp@3.1.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       comment-parser: 1.4.7
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       jsdoc-type-pratt-parser: 7.2.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-svelte@3.19.0(eslint@10.5.0)(svelte@5.56.4(@typescript-eslint/types@8.60.0)):
+  eslint-plugin-svelte@3.19.0(eslint@10.5.0(jiti@2.7.0))(svelte@5.56.4(@typescript-eslint/types@8.60.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@jridgewell/sourcemap-codec': 1.5.5
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
@@ -3377,26 +3738,26 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  eslint-plugin-toml@1.4.0(eslint@10.5.0):
+  eslint-plugin-toml@1.4.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@ota-meshi/ast-token-store': 0.3.0
       debug: 4.4.3
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       toml-eslint-parser: 1.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@64.0.0(eslint@10.5.0):
+  eslint-plugin-unicorn@64.0.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       change-case: 5.4.4
       ci-info: 4.4.0
       clean-regexp: 1.0.0
       core-js-compat: 3.49.0
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       find-up-simple: 1.0.1
       globals: 17.6.0
       indent-string: 5.0.0
@@ -3408,41 +3769,41 @@ snapshots:
       semver: 7.8.5
       strip-indent: 4.1.1
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
 
-  eslint-plugin-vue@10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0))(@typescript-eslint/parser@8.60.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(vue-eslint-parser@10.4.0(eslint@10.5.0)):
+  eslint-plugin-vue@10.9.1(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0)))(@typescript-eslint/parser@8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@10.5.0(jiti@2.7.0))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
-      eslint: 10.5.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      eslint: 10.5.0(jiti@2.7.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.4
       semver: 7.8.5
-      vue-eslint-parser: 10.4.0(eslint@10.5.0)
+      vue-eslint-parser: 10.4.0(eslint@10.5.0(jiti@2.7.0))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0)
-      '@typescript-eslint/parser': 8.60.0(eslint@10.5.0)(typescript@6.0.3)
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0(jiti@2.7.0))
+      '@typescript-eslint/parser': 8.60.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
 
-  eslint-plugin-yml@3.4.0(eslint@10.5.0):
+  eslint-plugin-yml@3.4.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@ota-meshi/ast-token-store': 0.3.0
       diff-sequences: 29.6.3
       escape-string-regexp: 5.0.0
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       natural-compare: 1.4.0
       yaml-eslint-parser: 2.0.0
 
-  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.35)(eslint@10.5.0):
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.35)(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@vue/compiler-sfc': 3.5.35
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -3462,9 +3823,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.5.0:
+  eslint@10.5.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.6.0
@@ -3494,6 +3855,8 @@ snapshots:
       minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -3632,6 +3995,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   is-builtin-module@5.0.0:
     dependencies:
       builtin-modules: 5.2.0
@@ -3649,6 +4014,8 @@ snapshots:
   isarray@1.0.0: {}
 
   isexe@2.0.0: {}
+
+  jiti@2.7.0: {}
 
   jsdoc-type-pratt-parser@7.1.1: {}
 
@@ -3764,6 +4131,8 @@ snapshots:
   long@4.0.0: {}
 
   longest-streak@3.1.0: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4119,6 +4488,12 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
+  mode-watcher@1.1.0(svelte@5.56.4(@typescript-eslint/types@8.60.0)):
+    dependencies:
+      runed: 0.25.0(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+      svelte: 5.56.4(@typescript-eslint/types@8.60.0)
+      svelte-toolbelt: 0.7.1(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+
   module-replacements@3.0.0-beta.7: {}
 
   mri@1.2.0: {}
@@ -4289,6 +4664,12 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qr-code-styling@1.9.2:
+    dependencies:
+      qrcode-generator: 1.5.2
+
+  qrcode-generator@1.5.2: {}
+
   quansync@0.2.11: {}
 
   readable-stream@2.3.8:
@@ -4347,6 +4728,25 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.3
       '@rolldown/binding-win32-x64-msvc': 1.1.3
 
+  runed@0.23.4(svelte@5.56.4(@typescript-eslint/types@8.60.0)):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.56.4(@typescript-eslint/types@8.60.0)
+
+  runed@0.25.0(svelte@5.56.4(@typescript-eslint/types@8.60.0)):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.56.4(@typescript-eslint/types@8.60.0)
+
+  runed@0.35.1(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0)):
+    dependencies:
+      dequal: 2.0.3
+      esm-env: 1.2.2
+      lz-string: 1.5.0
+      svelte: 5.56.4(@typescript-eslint/types@8.60.0)
+    optionalDependencies:
+      '@sveltejs/kit': 2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -4400,6 +4800,10 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
   svelte-check@4.7.0(picomatch@4.0.4)(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -4423,6 +4827,22 @@ snapshots:
       postcss-selector-parser: 7.1.4
       semver: 7.8.5
     optionalDependencies:
+      svelte: 5.56.4(@typescript-eslint/types@8.60.0)
+
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0)):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.35.1(@sveltejs/kit@2.67.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.60.0))(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+      style-to-object: 1.0.14
+      svelte: 5.56.4(@typescript-eslint/types@8.60.0)
+    transitivePeerDependencies:
+      - '@sveltejs/kit'
+
+  svelte-toolbelt@0.7.1(svelte@5.56.4(@typescript-eslint/types@8.60.0)):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.23.4(svelte@5.56.4(@typescript-eslint/types@8.60.0))
+      style-to-object: 1.0.14
       svelte: 5.56.4(@typescript-eslint/types@8.60.0)
 
   svelte@5.56.4(@typescript-eslint/types@8.60.0):
@@ -4449,6 +4869,18 @@ snapshots:
   synckit@0.11.13:
     dependencies:
       '@pkgr/core': 0.3.6
+
+  tabbable@6.5.0: {}
+
+  tailwind-merge@3.6.0: {}
+
+  tailwind-variants@3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2):
+    dependencies:
+      tailwindcss: 4.3.2
+    optionalDependencies:
+      tailwind-merge: 3.6.0
+
+  tailwindcss@4.3.2: {}
 
   tapable@2.3.3: {}
 
@@ -4482,8 +4914,9 @@ snapshots:
 
   tslib@2.4.0: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
+
+  tw-animate-css@1.4.0: {}
 
   type-check@0.4.0:
     dependencies:
@@ -4529,7 +4962,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0):
+  vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4539,16 +4972,17 @@ snapshots:
     optionalDependencies:
       esbuild: 0.27.7
       fsevents: 2.3.3
+      jiti: 2.7.0
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@8.1.0(esbuild@0.27.7)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.1.0(esbuild@0.27.7)(yaml@2.9.0)
+      vite: 8.1.0(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
 
-  vue-eslint-parser@10.4.0(eslint@10.5.0):
+  vue-eslint-parser@10.4.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3
-      eslint: 10.5.0
+      eslint: 10.5.0(jiti@2.7.0)
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0

--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,12 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
+			rel="stylesheet"
+		/>
 		<meta
 			name="description"
 			content="A collection of useful web-based utilities for image processing, PDF manipulation, and more"

--- a/src/lib/components/mode-toggle.svelte
+++ b/src/lib/components/mode-toggle.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Button } from "$lib/components/ui/button";
+	import { Moon, Sun } from "@lucide/svelte";
+	import { toggleMode } from "mode-watcher";
+</script>
+
+<Button variant="outline" size="icon" class="relative" onclick={toggleMode}>
+	<Sun class="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+	<Moon class="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+	<span class="sr-only">Toggle theme</span>
+</Button>

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -1,0 +1,77 @@
+<script lang="ts" module>
+	import type { VariantProps } from "tailwind-variants";
+	import { tv } from "tailwind-variants";
+
+	export const buttonVariants = tv({
+		base: "focus-visible:ring-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer",
+		variants: {
+			variant: {
+				default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+				destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+				outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+				secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+				ghost: "hover:bg-accent hover:text-accent-foreground",
+				link: "text-primary underline-offset-4 hover:underline",
+			},
+			size: {
+				default: "h-9 px-4 py-2",
+				sm: "h-8 rounded-md px-3 text-xs",
+				lg: "h-10 rounded-md px-6",
+				icon: "size-9",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	});
+
+	export type ButtonVariant = VariantProps<typeof buttonVariants>["variant"];
+	export type ButtonSize = VariantProps<typeof buttonVariants>["size"];
+</script>
+
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils";
+
+	type Props = WithElementRef<HTMLButtonAttributes>
+		& WithElementRef<HTMLAnchorAttributes>
+		& {
+			variant?: ButtonVariant;
+			size?: ButtonSize;
+		};
+
+	let {
+		class: className,
+		variant = "default",
+		size = "default",
+		ref = $bindable(null),
+		href = undefined,
+		type = "button",
+		children,
+		...restProps
+	}: Props = $props();
+</script>
+
+{#if href}
+	<!-- eslint-disable svelte/no-navigation-without-resolve -- href is resolved by the caller -->
+	<a
+		bind:this={ref}
+		class={cn(buttonVariants({ variant, size }), className)}
+		{href}
+		{...restProps}
+	>
+		{@render children?.()}
+	</a>
+	<!-- eslint-enable svelte/no-navigation-without-resolve -->
+{:else}
+	<button
+		bind:this={ref}
+		class={cn(buttonVariants({ variant, size }), className)}
+		{type}
+		{...restProps}
+	>
+		{@render children?.()}
+	</button>
+{/if}

--- a/src/lib/components/ui/button/index.ts
+++ b/src/lib/components/ui/button/index.ts
@@ -1,0 +1,13 @@
+import type { ButtonSize, ButtonVariant } from "./button.svelte";
+import Root, {
+
+	buttonVariants,
+} from "./button.svelte";
+
+export {
+	Root as Button,
+	type ButtonSize,
+	type ButtonVariant,
+	buttonVariants,
+	Root,
+};

--- a/src/lib/components/ui/card/card-content.svelte
+++ b/src/lib/components/ui/card/card-content.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div bind:this={ref} class={cn("px-6", className)} {...restProps}>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/card-description.svelte
+++ b/src/lib/components/ui/card/card-description.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/card-footer.svelte
+++ b/src/lib/components/ui/card/card-footer.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div bind:this={ref} class={cn("flex items-center px-6", className)} {...restProps}>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/card-header.svelte
+++ b/src/lib/components/ui/card/card-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("flex flex-col gap-1.5 px-6", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/card-title.svelte
+++ b/src/lib/components/ui/card/card-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("font-semibold leading-none tracking-tight", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/card.svelte
+++ b/src/lib/components/ui/card/card.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/card/index.ts
+++ b/src/lib/components/ui/card/index.ts
@@ -1,0 +1,21 @@
+import Content from "./card-content.svelte";
+import Description from "./card-description.svelte";
+import Footer from "./card-footer.svelte";
+import Header from "./card-header.svelte";
+import Title from "./card-title.svelte";
+import Root from "./card.svelte";
+
+export {
+	Root as Card,
+	Content as CardContent,
+	Description as CardDescription,
+	Footer as CardFooter,
+	Header as CardHeader,
+	Title as CardTitle,
+	Content,
+	Description,
+	Footer,
+	Header,
+	Root,
+	Title,
+};

--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { cn } from "$lib/utils";
+	import { Check, Minus } from "@lucide/svelte";
+	import { Checkbox as CheckboxPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		...restProps
+	}: CheckboxPrimitive.RootProps = $props();
+</script>
+
+<CheckboxPrimitive.Root
+	bind:ref
+	bind:checked
+	bind:indeterminate
+	class={cn(
+		"border-input focus-visible:border-ring focus-visible:ring-ring/40 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary peer size-4 shrink-0 rounded-[4px] border shadow-sm transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+		className,
+	)}
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<div class="flex items-center justify-center text-current transition-none">
+			{#if indeterminate}
+				<Minus class="size-3.5" />
+			{:else if checked}
+				<Check class="size-3.5" />
+			{/if}
+		</div>
+	{/snippet}
+</CheckboxPrimitive.Root>

--- a/src/lib/components/ui/checkbox/index.ts
+++ b/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,6 @@
+import Root from "./checkbox.svelte";
+
+export {
+	Root as Checkbox,
+	Root,
+};

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn } from "$lib/utils";
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		sideOffset = 4,
+		class: className,
+		...restProps
+	}: DropdownMenuPrimitive.ContentProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Portal>
+	<DropdownMenuPrimitive.Content
+		bind:ref
+		{sideOffset}
+		class={cn(
+			"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-50 max-h-[var(--bits-dropdown-menu-content-available-height)] min-w-[8rem] origin-[var(--bits-dropdown-menu-content-transform-origin)] overflow-y-auto overflow-x-hidden rounded-md border p-1 shadow-md",
+			className,
+		)}
+		{...restProps}
+	/>
+</DropdownMenuPrimitive.Portal>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { cn } from "$lib/utils";
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DropdownMenuPrimitive.ItemProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Item
+	bind:ref
+	class={cn(
+		"data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("text-muted-foreground px-2 py-1.5 text-xs font-medium", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { cn } from "$lib/utils";
+	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DropdownMenuPrimitive.SeparatorProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Separator
+	bind:ref
+	class={cn("bg-border -mx-1 my-1 h-px", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dropdown-menu/index.ts
+++ b/src/lib/components/ui/dropdown-menu/index.ts
@@ -1,0 +1,20 @@
+import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+import Content from "./dropdown-menu-content.svelte";
+import Item from "./dropdown-menu-item.svelte";
+import Label from "./dropdown-menu-label.svelte";
+import Separator from "./dropdown-menu-separator.svelte";
+
+const Root = DropdownMenuPrimitive.Root;
+const Trigger = DropdownMenuPrimitive.Trigger;
+const Group = DropdownMenuPrimitive.Group;
+
+export {
+	Content,
+	DropdownMenuPrimitive as DropdownMenu,
+	Group,
+	Item,
+	Label,
+	Root,
+	Separator,
+	Trigger,
+};

--- a/src/lib/components/ui/input/index.ts
+++ b/src/lib/components/ui/input/index.ts
@@ -1,0 +1,6 @@
+import Root from "./input.svelte";
+
+export {
+	Root as Input,
+	Root,
+};

--- a/src/lib/components/ui/input/input.svelte
+++ b/src/lib/components/ui/input/input.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLInputAttributes, HTMLInputTypeAttribute } from "svelte/elements";
+	import { cn } from "$lib/utils";
+
+	type Props = WithElementRef<Omit<HTMLInputAttributes, "type">, HTMLInputElement> & {
+		type?: HTMLInputTypeAttribute;
+	};
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		type = "text",
+		class: className,
+		...restProps
+	}: Props = $props();
+
+	const baseClass = "border-input bg-transparent placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/40 flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-sm shadow-sm transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50";
+</script>
+
+{#if type === "number"}
+	<input
+		bind:this={ref}
+		type="number"
+		bind:value
+		class={cn(baseClass, className)}
+		{...restProps}
+	/>
+{:else}
+	<input
+		bind:this={ref}
+		{type}
+		bind:value
+		class={cn(baseClass, className)}
+		{...restProps}
+	/>
+{/if}

--- a/src/lib/components/ui/label/index.ts
+++ b/src/lib/components/ui/label/index.ts
@@ -1,0 +1,6 @@
+import Root from "./label.svelte";
+
+export {
+	Root as Label,
+	Root,
+};

--- a/src/lib/components/ui/label/label.svelte
+++ b/src/lib/components/ui/label/label.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { cn } from "$lib/utils";
+	import { Label as LabelPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: LabelPrimitive.RootProps = $props();
+</script>
+
+<LabelPrimitive.Root
+	bind:ref
+	class={cn(
+		"flex items-center gap-2 text-sm font-medium leading-none select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+		className,
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/select/index.ts
+++ b/src/lib/components/ui/select/index.ts
@@ -1,0 +1,6 @@
+import Root from "./select.svelte";
+
+export {
+	Root,
+	Root as Select,
+};

--- a/src/lib/components/ui/select/select.svelte
+++ b/src/lib/components/ui/select/select.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { WithElementRef } from "$lib/utils";
+	import type { HTMLSelectAttributes } from "svelte/elements";
+	import { cn } from "$lib/utils";
+	import { ChevronDown } from "@lucide/svelte";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLSelectAttributes, HTMLSelectElement> = $props();
+</script>
+
+<div class="relative w-full">
+	<select
+		bind:this={ref}
+		bind:value
+		class={cn(
+			"border-input bg-transparent focus-visible:border-ring focus-visible:ring-ring/40 w-full appearance-none rounded-md border py-2 pr-8 pl-3 text-sm leading-tight shadow-sm transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+			className,
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+	</select>
+	<ChevronDown class="text-muted-foreground pointer-events-none absolute top-1/2 right-2.5 size-4 -translate-y-1/2" />
+</div>

--- a/src/lib/components/ui/slider/index.ts
+++ b/src/lib/components/ui/slider/index.ts
@@ -1,0 +1,6 @@
+import Root from "./slider.svelte";
+
+export {
+	Root,
+	Root as Slider,
+};

--- a/src/lib/components/ui/slider/slider.svelte
+++ b/src/lib/components/ui/slider/slider.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import type { WithoutChildrenOrChild } from "bits-ui";
+	import { cn } from "$lib/utils";
+	import { Slider as SliderPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		orientation = "horizontal",
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<SliderPrimitive.RootProps> = $props();
+</script>
+
+<SliderPrimitive.Root
+	bind:ref
+	bind:value={value as never}
+	{orientation}
+	class={cn(
+		"relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+		className,
+	)}
+	{...restProps}
+>
+	{#snippet children({ thumbItems })}
+		<span
+			data-orientation={orientation}
+			class="bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+		>
+			<SliderPrimitive.Range class="bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full" />
+		</span>
+		{#each thumbItems as { index } (index)}
+			<SliderPrimitive.Thumb
+				{index}
+				class="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+			/>
+		{/each}
+	{/snippet}
+</SliderPrimitive.Root>

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -1,0 +1,87 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+	--radius: 0.625rem;
+	--background: oklch(1 0 0);
+	--foreground: oklch(0.145 0 0);
+	--card: oklch(1 0 0);
+	--card-foreground: oklch(0.145 0 0);
+	--popover: oklch(1 0 0);
+	--popover-foreground: oklch(0.145 0 0);
+	--primary: oklch(0.55 0.16 240);
+	--primary-foreground: oklch(0.985 0 0);
+	--secondary: oklch(0.97 0 0);
+	--secondary-foreground: oklch(0.205 0 0);
+	--muted: oklch(0.97 0 0);
+	--muted-foreground: oklch(0.556 0 0);
+	--accent: oklch(0.97 0 0);
+	--accent-foreground: oklch(0.205 0 0);
+	--destructive: oklch(0.577 0.245 27.325);
+	--destructive-foreground: oklch(0.985 0 0);
+	--border: oklch(0.922 0 0);
+	--input: oklch(0.922 0 0);
+	--ring: oklch(0.55 0.16 240);
+}
+
+.dark {
+	--background: oklch(0.145 0 0);
+	--foreground: oklch(0.985 0 0);
+	--card: oklch(0.205 0 0);
+	--card-foreground: oklch(0.985 0 0);
+	--popover: oklch(0.205 0 0);
+	--popover-foreground: oklch(0.985 0 0);
+	--primary: oklch(0.7 0.15 240);
+	--primary-foreground: oklch(0.205 0 0);
+	--secondary: oklch(0.269 0 0);
+	--secondary-foreground: oklch(0.985 0 0);
+	--muted: oklch(0.269 0 0);
+	--muted-foreground: oklch(0.708 0 0);
+	--accent: oklch(0.269 0 0);
+	--accent-foreground: oklch(0.985 0 0);
+	--destructive: oklch(0.704 0.191 22.216);
+	--destructive-foreground: oklch(0.985 0 0);
+	--border: oklch(1 0 0 / 10%);
+	--input: oklch(1 0 0 / 15%);
+	--ring: oklch(0.7 0.15 240);
+}
+
+@theme inline {
+	--font-sans: "Manrope", ui-sans-serif, system-ui, -apple-system, sans-serif;
+	--color-background: var(--background);
+	--color-foreground: var(--foreground);
+	--color-card: var(--card);
+	--color-card-foreground: var(--card-foreground);
+	--color-popover: var(--popover);
+	--color-popover-foreground: var(--popover-foreground);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-secondary: var(--secondary);
+	--color-secondary-foreground: var(--secondary-foreground);
+	--color-muted: var(--muted);
+	--color-muted-foreground: var(--muted-foreground);
+	--color-accent: var(--accent);
+	--color-accent-foreground: var(--accent-foreground);
+	--color-destructive: var(--destructive);
+	--color-destructive-foreground: var(--destructive-foreground);
+	--color-border: var(--border);
+	--color-input: var(--input);
+	--color-ring: var(--ring);
+	--radius-sm: calc(var(--radius) - 4px);
+	--radius-md: calc(var(--radius) - 2px);
+	--radius-lg: var(--radius);
+	--radius-xl: calc(var(--radius) + 4px);
+}
+
+@layer base {
+	* {
+		border-color: var(--border);
+	}
+
+	body {
+		background-color: var(--background);
+		color: var(--foreground);
+	}
+}

--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -4,11 +4,19 @@
 }
 
 body {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+	font-family:
+		"Manrope",
+		ui-sans-serif,
+		system-ui,
+		-apple-system,
+		BlinkMacSystemFont,
+		"Segoe UI",
+		Roboto,
+		sans-serif;
 	margin: 0;
 	padding: 0;
-	background: #fafafa;
-	color: #1a202c;
+	background: var(--background);
+	color: var(--foreground);
 }
 
 /* Layout */
@@ -19,27 +27,29 @@ body {
 }
 
 /* Typography */
-h1 {
+/* Wrapped in :where() so migrated (Tailwind) pages can override with a single
+   utility class; legacy pages still receive these defaults. */
+:where(h1) {
 	font-size: 2rem;
 	margin-bottom: 0.5rem;
-	color: #1a202c;
+	color: var(--foreground);
 }
 
-h2 {
+:where(h2) {
 	font-size: 1.25rem;
-	color: #2d3748;
+	color: var(--foreground);
 	margin-bottom: 1rem;
 }
 
 .subtitle {
-	color: #666;
+	color: var(--muted-foreground);
 	margin-bottom: 2rem;
 }
 
 /* Links */
 .back-link {
 	display: inline-block;
-	color: #007acc;
+	color: var(--primary);
 	text-decoration: none;
 	margin-bottom: 1.5rem;
 }
@@ -50,42 +60,42 @@ h2 {
 
 /* Cards */
 .card {
-	background: white;
-	border: 1px solid #e0e0e0;
+	background: var(--card);
+	color: var(--card-foreground);
+	border: 1px solid var(--border);
 	border-radius: 12px;
 	padding: 1.5rem;
 }
 
 .card-section {
-	background: #f7fafc;
+	background: var(--muted);
+	border: 1px solid var(--border);
 	border-radius: 12px;
 	padding: 1.5rem;
 	margin-bottom: 1.5rem;
 }
 
 /* Form elements */
-label {
+:where(label) {
 	font-size: 0.85rem;
 	font-weight: 500;
-	color: #4a5568;
+	color: var(--foreground);
 }
 
-input[type="text"],
-input[type="number"],
-select {
+:where(input[type="text"], input[type="number"], select) {
 	padding: 0.6rem;
-	border: 1px solid #e2e8f0;
+	border: 1px solid var(--input);
 	border-radius: 8px;
 	font-size: 1rem;
-	background: white;
+	background: var(--background);
+	color: var(--foreground);
 	width: 100%;
 }
 
-input:focus,
-select:focus {
+:where(input:focus, select:focus) {
 	outline: none;
-	border-color: #007acc;
-	box-shadow: 0 0 0 3px rgba(0, 122, 204, 0.1);
+	border-color: var(--ring);
+	box-shadow: 0 0 0 3px color-mix(in oklab, var(--ring) 25%, transparent);
 }
 
 /* Buttons */
@@ -103,14 +113,14 @@ select:focus {
 }
 
 .btn-primary {
-	background: #007acc;
-	color: white;
+	background: var(--primary);
+	color: var(--primary-foreground);
 }
 
 .btn-primary:hover:not(:disabled) {
-	background: #006bb3;
+	background: color-mix(in oklab, var(--primary) 90%, black);
 	transform: translateY(-1px);
-	box-shadow: 0 4px 12px rgba(0, 122, 204, 0.3);
+	box-shadow: 0 4px 12px color-mix(in oklab, var(--primary) 30%, transparent);
 }
 
 .btn:disabled {
@@ -120,18 +130,18 @@ select:focus {
 
 /* Drop zone */
 .drop-zone {
-	border: 2px dashed #cbd5e0;
+	border: 2px dashed var(--border);
 	border-radius: 12px;
 	padding: 2rem;
 	text-align: center;
 	transition: all 0.3s ease;
 	cursor: pointer;
-	background: #f7fafc;
+	background: var(--muted);
 }
 
 .drop-zone:hover {
-	border-color: #007acc;
-	background: #f0f7ff;
+	border-color: var(--ring);
+	background: var(--accent);
 }
 
 .drop-zone.has-file {
@@ -142,7 +152,7 @@ select:focus {
 
 /* Utility classes */
 .text-muted {
-	color: #718096;
+	color: var(--muted-foreground);
 }
 
 .text-success {

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,0 +1,61 @@
+import type { Tool } from "$lib/types";
+import { Columns3, Files, Globe, Grid2x2, Images, LayoutGrid, QrCode, Shrink } from "@lucide/svelte";
+
+export const tools: Tool[] = [
+	{
+		name: "Collage Creator",
+		description: "Build grid, masonry, or scattered photo collages",
+		path: "/tools/collage-creator",
+		icon: Grid2x2,
+		status: "ready",
+	},
+	{
+		name: "Instagram Carousel Creator",
+		description: "Create stunning carousel posts for Instagram",
+		path: "/tools/instagram-carousel",
+		icon: Images,
+		status: "ready",
+	},
+	{
+		name: "Panorama Splitter",
+		description: "Split wide panorama images into Instagram carousel slides",
+		path: "/tools/panorama-splitter",
+		icon: Columns3,
+		status: "ready",
+	},
+	{
+		name: "Batch Image Compressor",
+		description: "Compress, resize, and convert many images at once",
+		path: "/tools/image-compressor",
+		icon: Shrink,
+		status: "ready",
+	},
+	{
+		name: "PDF Imposition Tool",
+		description: "Arrange PDF pages for professional printing layouts",
+		path: "/tools/pdf-imposition",
+		icon: LayoutGrid,
+		status: "ready",
+	},
+	{
+		name: "PDF Organizer",
+		description: "Merge, split, reorder, rotate, and extract PDF pages",
+		path: "/tools/pdf-organizer",
+		icon: Files,
+		status: "ready",
+	},
+	{
+		name: "Favicon Extractor",
+		description: "Find and download favicon files from a website",
+		path: "/tools/favicon-extractor",
+		icon: Globe,
+		status: "ready",
+	},
+	{
+		name: "QR Code Generator",
+		description: "Generate custom QR codes with colors, styles, and a logo",
+		path: "/tools/qr-code-generator",
+		icon: QrCode,
+		status: "ready",
+	},
+];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,7 +1,9 @@
+import type { Component } from "svelte";
+
 export interface Tool {
 	name: string;
 	description: string;
 	path: string;
-	icon: string;
+	icon: Component<{ class?: string }>;
 	status: "ready" | "coming-soon";
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import type { ClassValue } from "clsx";
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+	return twMerge(clsx(inputs));
+}
+
+export type WithElementRef<T, U extends HTMLElement = HTMLElement> = T & { ref?: U | null };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,13 +1,65 @@
 <script lang="ts">
+	import type { Pathname } from "$app/types";
 	import type { Snippet } from "svelte";
+	import { resolve as resolvePath } from "$app/paths";
+	import { page } from "$app/state";
+	import ModeToggle from "$lib/components/mode-toggle.svelte";
+	import { Button } from "$lib/components/ui/button";
+	import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+	import { tools } from "$lib/tools";
+	import { cn } from "$lib/utils";
+	import { Check, ChevronDown, Wrench } from "@lucide/svelte";
+	import { ModeWatcher } from "mode-watcher";
 	import packageJson from "../../package.json";
+	import "$lib/styles/app.css";
 	import "$lib/styles/global.css";
 
 	const { children }: { children: Snippet } = $props();
 	const appVersion = packageJson.version;
 </script>
 
+<ModeWatcher />
+
 <div class="app-shell">
+	<header class="site-header">
+		<a href={resolvePath("/")} class="brand">
+			<Wrench class="size-5" />
+			Tools
+		</a>
+		<div class="flex items-center gap-2">
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger>
+					{#snippet child({ props })}
+						<Button variant="outline" size="sm" {...props}>
+							Tools
+							<ChevronDown class="size-4" />
+						</Button>
+					{/snippet}
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content align="end" class="w-64">
+					<DropdownMenu.Label>Jump to tool</DropdownMenu.Label>
+					<DropdownMenu.Separator />
+					{#each tools as tool (tool.path)}
+						{@const Icon = tool.icon}
+						{@const href = resolvePath(tool.path as Pathname)}
+						{@const active = page.url.pathname === href}
+						<DropdownMenu.Item class={cn(active && "bg-accent")}>
+							{#snippet child({ props })}
+								<a {href} {...props}>
+									<Icon class="text-muted-foreground size-4" />
+									<span class="flex-1">{tool.name}</span>
+									{#if active}
+										<Check class="size-4" />
+									{/if}
+								</a>
+							{/snippet}
+						</DropdownMenu.Item>
+					{/each}
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+			<ModeToggle />
+		</div>
+	</header>
 	<div class="app-main">
 		{@render children()}
 	</div>
@@ -23,6 +75,26 @@
 		min-height: 100vh;
 		display: flex;
 		flex-direction: column;
+	}
+
+	.site-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		max-width: 900px;
+		width: 100%;
+		margin: 0 auto;
+		padding: 1rem 2rem 0;
+	}
+
+	.brand {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-weight: 600;
+		font-size: 1.05rem;
+		text-decoration: none;
+		color: inherit;
 	}
 
 	.app-main {
@@ -42,5 +114,11 @@
 
 	.site-footer a {
 		color: inherit;
+	}
+
+	@media (max-width: 600px) {
+		.site-header {
+			padding: 1rem 1rem 0;
+		}
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,125 +1,40 @@
 <script lang="ts">
-	import type { Tool } from "$lib/types";
+	import type { Pathname } from "$app/types";
 	import { resolve as resolvePath } from "$app/paths";
-
-	const tools: Tool[] = [
-		{
-			name: "Collage Creator",
-			description: "Build grid, masonry, or scattered photo collages",
-			path: "/tools/collage-creator",
-			icon: "🧩",
-			status: "ready",
-		},
-		{
-			name: "Instagram Carousel Creator",
-			description: "Create stunning carousel posts for Instagram",
-			path: "/tools/instagram-carousel",
-			icon: "📸",
-			status: "ready",
-		},
-		{
-			name: "Panorama Splitter",
-			description: "Split wide panorama images into Instagram carousel slides",
-			path: "/tools/panorama-splitter",
-			icon: "🌄",
-			status: "ready",
-		},
-		{
-			name: "Batch Image Compressor",
-			description: "Compress, resize, and convert many images at once",
-			path: "/tools/image-compressor",
-			icon: "🗜️",
-			status: "ready",
-		},
-		{
-			name: "PDF Imposition Tool",
-			description: "Arrange PDF pages for professional printing layouts",
-			path: "/tools/pdf-imposition",
-			icon: "📄",
-			status: "ready",
-		},
-		{
-			name: "Favicon Extractor",
-			description: "Find and download favicon files from a website",
-			path: "/tools/favicon-extractor",
-			icon: "🌐",
-			status: "ready",
-		},
-	];
+	import * as Card from "$lib/components/ui/card";
+	import { tools } from "$lib/tools";
 </script>
 
 <svelte:head>
 	<title>Tools Directory</title>
 </svelte:head>
 
-<main class="page-container">
-	<h1>Tools Directory</h1>
-	<p class="subtitle">A collection of useful utilities</p>
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<h1 class="mb-1 text-3xl font-bold tracking-tight">Tools Directory</h1>
+	<p class="text-muted-foreground mb-8">A collection of useful utilities</p>
 
-	<div class="tools-grid">
+	<div class="grid gap-4 sm:grid-cols-2">
 		{#each tools as tool (tool.path)}
-			<a href={resolvePath(tool.path as Parameters<typeof resolvePath>[0])} class="tool-card card" class:coming-soon={tool.status === "coming-soon"}>
-				<span class="icon">{tool.icon}</span>
-				<h2>{tool.name}</h2>
-				<p class="text-muted">{tool.description}</p>
-				{#if tool.status === "coming-soon"}
-					<span class="badge">Coming Soon</span>
-				{/if}
+			{@const Icon = tool.icon}
+			<a
+				href={resolvePath(tool.path as Pathname)}
+				class="group focus-visible:ring-ring rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-offset-2 {tool.status === "coming-soon" ? "pointer-events-none opacity-60" : ""}"
+			>
+				<Card.Root class="relative h-full gap-3 transition-all group-hover:-translate-y-0.5 group-hover:shadow-md">
+					<Card.Header>
+						<div class="bg-primary/10 text-primary flex size-11 items-center justify-center rounded-lg">
+							<Icon class="size-6" />
+						</div>
+					</Card.Header>
+					<Card.Content class="space-y-1">
+						<Card.Title class="text-lg">{tool.name}</Card.Title>
+						<Card.Description>{tool.description}</Card.Description>
+					</Card.Content>
+					{#if tool.status === "coming-soon"}
+						<span class="bg-muted text-muted-foreground absolute top-4 right-4 rounded px-2 py-0.5 text-xs">Coming Soon</span>
+					{/if}
+				</Card.Root>
 			</a>
 		{/each}
 	</div>
 </main>
-
-<style>
-	.tools-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-		gap: 1.5rem;
-	}
-
-	.tool-card {
-		display: block;
-		text-decoration: none;
-		color: inherit;
-		transition: all 0.2s ease;
-		position: relative;
-	}
-
-	.tool-card:hover {
-		border-color: #007acc;
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-		transform: translateY(-2px);
-	}
-
-	.tool-card.coming-soon {
-		opacity: 0.7;
-		pointer-events: none;
-	}
-
-	.icon {
-		font-size: 2rem;
-		display: block;
-		margin-bottom: 0.5rem;
-	}
-
-	.tool-card h2 {
-		font-size: 1.25rem;
-		margin-bottom: 0.5rem;
-	}
-
-	.tool-card p {
-		font-size: 0.9rem;
-		margin: 0;
-	}
-
-	.badge {
-		position: absolute;
-		top: 1rem;
-		right: 1rem;
-		background: #f0f0f0;
-		padding: 0.25rem 0.5rem;
-		border-radius: 4px;
-		font-size: 0.75rem;
-		color: #666;
-	}
-</style>

--- a/src/routes/tools/collage-creator/+page.svelte
+++ b/src/routes/tools/collage-creator/+page.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
 	import { resolve as resolvePath } from "$app/paths";
+	import { Button, buttonVariants } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Checkbox } from "$lib/components/ui/checkbox";
+	import { Input } from "$lib/components/ui/input";
+	import { Label } from "$lib/components/ui/label";
+	import { Select } from "$lib/components/ui/select";
+	import { Slider } from "$lib/components/ui/slider";
+	import { cn } from "$lib/utils";
+	import { Download, Grid2x2, LoaderCircle, RefreshCw, Shuffle, Upload } from "@lucide/svelte";
 	import { onDestroy, onMount, tick } from "svelte";
 
 	type LayoutMode = "grid" | "masonry" | "scattered";
@@ -987,717 +996,281 @@
 	<title>Collage Creator</title>
 </svelte:head>
 
-<main class="page-container">
-	<a href={resolvePath("/")} class="back-link">← Back to Tools</a>
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
 
-	<h1>🧩 Collage Creator</h1>
-	<p class="subtitle">Build clean grids, bold masonry layouts, or scattered collages in seconds.</p>
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight"><Grid2x2 class="text-primary size-7" /> Collage Creator</h1>
+	<p class="text-muted-foreground mb-8">Build clean grids, bold masonry layouts, or scattered collages in seconds.</p>
 
-	<section class="card-section">
-		<div class="section-header">
-			<h2>Upload Images</h2>
+	<Card.Root class="mb-6">
+		<Card.Header class="flex-row items-center justify-between space-y-0">
+			<Card.Title>Upload Images</Card.Title>
 			{#if images.length > 0}
-				<button type="button" class="btn btn-small" onclick={clearImages}>Clear All</button>
+				<Button variant="outline" size="sm" onclick={clearImages}>Clear All</Button>
 			{/if}
-		</div>
-		<div
-			class="drop-zone"
-			class:has-images={images.length > 0}
-			ondrop={handleImageDrop}
-			ondragover={handleDragOver}
-			role="button"
-			tabindex="0"
-		>
-			<div class="drop-content">
-				<span class="upload-icon">📥</span>
-				<p>Drag & drop images here</p>
-				<p class="text-muted">or</p>
-				<div class="drop-actions">
-					<label class="btn btn-primary">
-						{images.length > 0 ? "Add More Images" : "Browse Images"}
-						<input type="file" accept="image/*" multiple onchange={handleImageSelect} hidden />
-					</label>
-				</div>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			<label
+				class="border-input hover:border-ring hover:bg-accent bg-muted/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
+				ondrop={handleImageDrop}
+				ondragover={handleDragOver}
+			>
+				<Upload class="text-muted-foreground size-9" />
+				<p class="font-medium">Drag & drop images here</p>
+				<p class="text-muted-foreground text-sm">or click to browse</p>
 				{#if images.length > 0}
-					<p class="text-muted">{images.length} image{images.length === 1 ? "" : "s"} ready</p>
+					<p class="text-muted-foreground text-sm">{images.length} image{images.length === 1 ? "" : "s"} ready</p>
 				{/if}
+				<input type="file" accept="image/*" multiple onchange={handleImageSelect} hidden />
+			</label>
+			{#if loadingImages}
+				<div class="text-muted-foreground flex items-center gap-2 text-sm">
+					<LoaderCircle class="size-4 animate-spin" />
+					<span>Loading {loadingCount} of {loadingTotal} images…</span>
+				</div>
+			{/if}
+			{#if error}
+				<div class="border-destructive/40 bg-destructive/10 text-destructive rounded-lg border px-4 py-3 text-sm">{error}</div>
+			{/if}
+			{#if images.length > 0}
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(110px,1fr))] gap-3">
+					{#each images as image, index (image.previewUrl)}
+						<div class="group relative overflow-hidden rounded-md border" role="listitem">
+							<img src={image.previewUrl} alt="Preview {index + 1}" class="aspect-square w-full object-cover" />
+							<button
+								type="button"
+								class="bg-background/80 hover:bg-destructive hover:text-destructive-foreground absolute top-1 right-1 flex size-6 items-center justify-center rounded-full text-xs opacity-0 transition group-hover:opacity-100"
+								aria-label="Remove image {index + 1}"
+								onclick={() => removeImageAt(index)}
+							>✕</button>
+							<span class="bg-background/80 absolute bottom-1 left-1 rounded px-1.5 py-0.5 text-xs font-medium">{index + 1}</span>
+						</div>
+					{/each}
+				</div>
+				<div class="space-y-2">
+					<Label class="font-normal">
+						<Checkbox bind:checked={faceDetectionEnabled} disabled={!faceDetectorSupported} onCheckedChange={handleFaceToggle} />
+						Face-aware Positioning
+					</Label>
+					<p class="text-muted-foreground text-sm">
+						{#if faceDetectorSupported}
+							Detect faces and keep them centered in each crop.
+						{:else}
+							Face detection is not supported in this browser.
+						{/if}
+					</p>
+					{#if faceDetectionEnabled && (tfjsLoading || detectionInProgress)}
+						<p class="text-muted-foreground text-sm">Detecting faces…</p>
+						{#if detectionTotal > 0}
+							<div class="flex items-center gap-2">
+								<div class="bg-muted h-2 flex-1 overflow-hidden rounded-full">
+									<div class="bg-primary h-full transition-all" style="width: {Math.min(100, Math.round((detectionCount / detectionTotal) * 100))}%;"></div>
+								</div>
+								<span class="text-muted-foreground text-xs">{Math.min(100, Math.round((detectionCount / detectionTotal) * 100))}%</span>
+							</div>
+						{/if}
+					{/if}
+					{#if faceDetectionEnabled && detectionComplete}
+						<p class="text-sm text-emerald-600 dark:text-emerald-400">Face detection complete ✓</p>
+					{/if}
+					{#if detectionError}
+						<p class="text-sm text-amber-600 dark:text-amber-400">{detectionError}</p>
+					{/if}
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="mb-6">
+		<Card.Header><Card.Title>Canvas Settings</Card.Title></Card.Header>
+		<Card.Content>
+			<div class="grid grid-cols-2 gap-3">
+				<div class="grid gap-1.5">
+					<Label for="aspectRatio">Aspect Ratio</Label>
+					<Select id="aspectRatio" bind:value={aspectRatio}>
+						{#each aspectRatios as option (option.value)}
+							<option value={option.value}>{option.label}</option>
+						{/each}
+					</Select>
+				</div>
+				<div class="grid gap-1.5">
+					<Label for="resolution">Resolution (width px)</Label>
+					<Input id="resolution" type="number" min={600} max={8000} step={10} bind:value={resolution} />
+					<span class="text-muted-foreground text-xs">{canvasWidth} × {canvasHeight}px</span>
+				</div>
 			</div>
-		</div>
-		{#if loadingImages}
-			<div class="loading-row">
-				<span class="loading-spinner"></span>
-				<span>Loading {loadingCount} of {loadingTotal} images…</span>
-			</div>
-		{/if}
-		{#if error}
-			<p class="alert alert-error">{error}</p>
-		{/if}
-		{#if images.length > 0}
-			<p class="text-muted reorder-hint">Preview</p>
-			<div class="image-grid">
-				{#each images as image, index (image.previewUrl)}
-					<div class="image-item" role="listitem">
-						<img src={image.previewUrl} alt="Preview {index + 1}" />
-						<button
-							type="button"
-							class="image-remove"
-							aria-label="Remove image {index + 1}"
-							onclick={() => removeImageAt(index)}
-						>
-							✕
-						</button>
-						<span class="image-number">{index + 1}</span>
-					</div>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="mb-6">
+		<Card.Header><Card.Title>Layout</Card.Title></Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="grid gap-3 sm:grid-cols-3">
+				{#each [{ value: "grid" as const, name: "Grid", desc: "Even rows and columns" }, { value: "masonry" as const, name: "Masonry", desc: "Stacked with varied heights" }, { value: "scattered" as const, name: "Scattered", desc: "Loose, layered collage" }] as option (option.value)}
+					<button
+						type="button"
+						class={cn("flex flex-col items-start gap-1 rounded-lg border p-4 text-left transition-colors", layoutMode === option.value ? "border-primary bg-accent" : "border-border hover:bg-accent/50")}
+						onclick={() => (layoutMode = option.value)}
+					>
+						<span class="font-semibold">{option.name}</span>
+						<span class="text-muted-foreground text-sm">{option.desc}</span>
+					</button>
 				{/each}
 			</div>
-			<div class="setting-group mt-2">
-				<label class="switch">
-					<input
-						type="checkbox"
-						bind:checked={faceDetectionEnabled}
-						disabled={!faceDetectorSupported}
-						onchange={handleFaceToggle}
-					/>
-					<span>Face-aware Positioning</span>
-				</label>
-				<span class="text-muted">
-					{#if faceDetectorSupported}
-						Detect faces and keep them centered in each crop.
-					{:else}
-						Face detection is not supported in this browser.
-					{/if}
-				</span>
-				{#if faceDetectionEnabled && (tfjsLoading || detectionInProgress)}
-					<span class="text-muted">
-						Detecting faces…
-					</span>
-					{#if detectionTotal > 0}
-						<div class="progress-row">
-							<div class="progress-track">
-								<div class="progress-fill" style="width: {Math.min(100, Math.round((detectionCount / detectionTotal) * 100))}%;"></div>
-							</div>
-							<span class="progress-text">
-								{Math.min(100, Math.round((detectionCount / detectionTotal) * 100))}%
-							</span>
-						</div>
-					{/if}
-				{/if}
-				{#if faceDetectionEnabled && detectionComplete}
-					<span class="text-muted text-success">Face detection complete ✓</span>
-				{/if}
-				{#if detectionError}
-					<span class="text-muted text-warning">{detectionError}</span>
-				{/if}
-			</div>
-		{/if}
-	</section>
-
-	<section class="card-section">
-		<h2>Canvas Settings</h2>
-		<div class="settings-grid">
-			<div class="setting-group">
-				<label for="aspectRatio">Aspect Ratio</label>
-				<select id="aspectRatio" bind:value={aspectRatio}>
-					{#each aspectRatios as option (option.value)}
-						<option value={option.value}>{option.label}</option>
-					{/each}
-				</select>
-			</div>
-			<div class="setting-group">
-				<label for="resolution">Resolution (width px)</label>
-				<input id="resolution" type="number" min="600" max="8000" step="10" bind:value={resolution} />
-				<span class="text-muted">{canvasWidth} × {canvasHeight}px</span>
-			</div>
-		</div>
-	</section>
-
-	<section class="card-section">
-		<h2>Layout</h2>
-		<div class="layout-mode-selector">
-			<button
-				type="button"
-				class="btn layout-btn"
-				class:active={layoutMode === "grid"}
-				onclick={() => {
-					layoutMode = "grid";
-				}}
-			>
-				<span class="layout-icon">▦</span>
-				<span class="layout-name">Grid</span>
-				<span class="layout-desc">Even rows and columns</span>
-			</button>
-			<button
-				type="button"
-				class="btn layout-btn"
-				class:active={layoutMode === "masonry"}
-				onclick={() => {
-					layoutMode = "masonry";
-				}}
-			>
-				<span class="layout-icon">▥</span>
-				<span class="layout-name">Masonry</span>
-				<span class="layout-desc">Stacked with varied heights</span>
-			</button>
-			<button
-				type="button"
-				class="btn layout-btn"
-				class:active={layoutMode === "scattered"}
-				onclick={() => {
-					layoutMode = "scattered";
-				}}
-			>
-				<span class="layout-icon">✦</span>
-				<span class="layout-name">Scattered</span>
-				<span class="layout-desc">Loose, layered collage</span>
-			</button>
-		</div>
-		<div class="settings-grid mt-2">
-			<div class="setting-row">
-				<div class="setting-group">
-					<label for="columns">Columns</label>
-					<input id="columns" type="number" min="1" max="8" bind:value={columns} />
-					<span class="text-muted">Applies to grid and masonry</span>
+			<div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+				<div class="grid gap-1.5">
+					<Label for="columns">Columns</Label>
+					<Input id="columns" type="number" min={1} max={8} bind:value={columns} />
 				</div>
-				<div class="setting-group">
-					<label for="gap">Gap (px)</label>
-					<input id="gap" type="number" min="0" max="200" step="1" bind:value={gap} />
+				<div class="grid gap-1.5">
+					<Label for="gap">Gap (px)</Label>
+					<Input id="gap" type="number" min={0} max={200} step={1} bind:value={gap} />
 				</div>
-			</div>
-			<div class="setting-group">
-				<label for="outerMargin">Outer Margin (px)</label>
-				<input id="outerMargin" type="number" min="0" max="300" step="1" bind:value={outerMargin} />
-				<span class="text-muted">Adds space between the collage and the canvas edge.</span>
+				<div class="grid gap-1.5">
+					<Label for="outerMargin">Outer Margin (px)</Label>
+					<Input id="outerMargin" type="number" min={0} max={300} step={1} bind:value={outerMargin} />
+				</div>
 			</div>
 			{#if layoutMode === "scattered"}
-				<div class="setting-group">
-					<label for="scatterVariation">Scatter Variation</label>
-					<button class="btn btn-secondary" type="button" onclick={randomizeSeed}>Randomize</button>
-					<div class="slider-group">
-						<input
-							id="scatterVariation"
-							type="range"
-							min="0"
-							max="100"
-							bind:value={scatterVariation}
-						/>
-						<span class="slider-value">{scatterVariation}%</span>
+				<div class="grid gap-1.5">
+					<div class="flex items-center justify-between">
+						<Label for="scatterVariation">Scatter Variation ({scatterVariation}%)</Label>
+						<Button variant="outline" size="sm" onclick={randomizeSeed}><Shuffle class="size-4" /> Randomize</Button>
 					</div>
-					<span class="text-muted">Re-shuffles the scattered layout.</span>
+					<div class="flex h-9 items-center"><Slider id="scatterVariation" type="single" min={0} max={100} bind:value={scatterVariation} /></div>
 				</div>
 			{/if}
-		</div>
-		{#if gridDropCount > 0}
-			<p class="alert alert-warning">
-				{gridDropCount} image{gridDropCount === 1 ? "" : "s"} dropped to keep the grid even.
-			</p>
-		{/if}
-	</section>
+			{#if gridDropCount > 0}
+				<div class="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
+					{gridDropCount} image{gridDropCount === 1 ? "" : "s"} dropped to keep the grid even.
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
 
-	<section class="card-section">
-		<h2>Background</h2>
-		<div class="settings-grid">
-			<div class="setting-group">
-				<label for="backgroundType">Background Type</label>
-				<select id="backgroundType" bind:value={backgroundType}>
+	<Card.Root class="mb-6">
+		<Card.Header><Card.Title>Background</Card.Title></Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="grid gap-1.5 sm:max-w-xs">
+				<Label for="backgroundType">Background Type</Label>
+				<Select id="backgroundType" bind:value={backgroundType}>
 					<option value="color">Solid Color</option>
 					<option value="gradient">Gradient</option>
 					<option value="image">Image</option>
-				</select>
+				</Select>
 			</div>
 			{#if backgroundType === "color"}
-				<div class="color-picker-section">
-					<div class="color-preview-large" style="background: {backgroundColor};"></div>
-					<div class="color-controls">
-						<label class="color-input-row" for="backgroundColor">
-							<span>Color</span>
-							<input id="backgroundColor" type="color" bind:value={backgroundColor} />
-							<input class="color-hex-input" type="text" bind:value={backgroundColor} />
-						</label>
+				<div class="flex flex-wrap items-center gap-4">
+					<div class="size-16 shrink-0 rounded-lg border" style="background: {backgroundColor};"></div>
+					<div class="flex items-center gap-2">
+						<input id="backgroundColor" type="color" bind:value={backgroundColor} class="border-input size-9 shrink-0 cursor-pointer rounded-md border bg-transparent p-1" />
+						<Input type="text" bind:value={backgroundColor} class="w-28 font-mono" />
 					</div>
 				</div>
 			{:else if backgroundType === "gradient"}
-				<div class="gradient-picker-section">
-					<div
-						class="color-preview-large"
-						style="background: linear-gradient({gradientAngle}deg, {gradientColorStart}, {gradientColorEnd});"
-					></div>
-					<div class="gradient-controls">
-						<label class="color-input-row" for="gradientColorStart">
-							<span>Start</span>
-							<input id="gradientColorStart" type="color" bind:value={gradientColorStart} />
-							<input class="color-hex-input" type="text" bind:value={gradientColorStart} />
-						</label>
-						<label class="color-input-row" for="gradientColorEnd">
-							<span>End</span>
-							<input id="gradientColorEnd" type="color" bind:value={gradientColorEnd} />
-							<input class="color-hex-input" type="text" bind:value={gradientColorEnd} />
-						</label>
-						<div class="color-input-row">
-							<span>Angle</span>
-							<input id="gradientAngle" type="number" min="0" max="360" bind:value={gradientAngle} />
+				<div class="space-y-4">
+					<div class="h-24 w-full rounded-lg border" style="background: linear-gradient({gradientAngle}deg, {gradientColorStart}, {gradientColorEnd});"></div>
+					<div class="flex flex-wrap items-end gap-4">
+						<div class="flex items-center gap-2">
+							<input id="gradientColorStart" type="color" bind:value={gradientColorStart} class="border-input size-9 shrink-0 cursor-pointer rounded-md border bg-transparent p-1" />
+							<Input type="text" bind:value={gradientColorStart} class="w-28 font-mono" />
+						</div>
+						<div class="flex items-center gap-2">
+							<input id="gradientColorEnd" type="color" bind:value={gradientColorEnd} class="border-input size-9 shrink-0 cursor-pointer rounded-md border bg-transparent p-1" />
+							<Input type="text" bind:value={gradientColorEnd} class="w-28 font-mono" />
+						</div>
+						<div class="grid gap-1.5">
+							<Label for="gradientAngle">Angle</Label>
+							<Input id="gradientAngle" type="number" min={0} max={360} bind:value={gradientAngle} class="w-24" />
 						</div>
 					</div>
 				</div>
 			{:else}
-				<div class="setting-group">
-					<label for="backgroundImage">Background Image</label>
-					<div class="bg-upload">
-						{#if backgroundUrl}
-							<img src={backgroundUrl} alt="Background preview" />
-						{/if}
-						<div class="bg-upload-actions">
-							<label class="btn btn-primary">
-								{backgroundFile ? "Replace Image" : "Upload Image"}
-								<input id="backgroundImage" type="file" accept="image/*" onchange={handleBackgroundSelect} hidden />
-							</label>
-							{#if backgroundFile}
-								<button class="btn btn-secondary" type="button" onclick={clearBackgroundImage}>Remove</button>
-							{/if}
-						</div>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</section>
-
-	<section class="card-section">
-		<h2>Feather & Overlap</h2>
-		<div class="settings-grid">
-			<div class="setting-group">
-				<label class="switch">
-					<input type="checkbox" bind:checked={featherEnabled} />
-					<span>Enable Feathering</span>
-				</label>
-				<span class="text-muted">Softly blend overlaps without affecting the outer edges.</span>
-			</div>
-			<div class="setting-group">
-				<label class="switch">
-					<input type="checkbox" bind:checked={roundedCorners} />
-					<span>Rounded Corners</span>
-				</label>
-				<span class="text-muted">Smooth corners on each image.</span>
-			</div>
-			{#if featherEnabled}
-				<div class="setting-group">
-					<label for="featherAmount">Feather Strength (px)</label>
-					<input id="featherAmount" type="number" min="4" max="120" step="1" bind:value={featherAmount} />
-				</div>
-			{/if}
-			{#if roundedCorners}
-				<div class="setting-group">
-					<label for="cornerRadius">Corner Radius (px)</label>
-					<input id="cornerRadius" type="number" min="0" max="120" step="1" bind:value={cornerRadius} />
-				</div>
-			{/if}
-		</div>
-	</section>
-
-	<section class="card-section">
-		<h2>Preview</h2>
-		<div class="preview-grid">
-			<div class="canvas-panel">
-				<canvas bind:this={canvasRef} class="collage-canvas"></canvas>
-				<div class="export-row">
-					<div class="setting-group">
-						<label for="exportFormat">Export Format</label>
-						<select id="exportFormat" bind:value={exportFormat}>
-							<option value="png">PNG</option>
-							<option value="jpg">JPEG</option>
-						</select>
-					</div>
-					{#if exportFormat === "jpg"}
-						<div class="setting-group">
-							<label for="jpgQuality">JPEG Quality</label>
-							<input id="jpgQuality" type="number" min="60" max="100" step="1" bind:value={jpgQuality} />
-						</div>
+				<div class="flex flex-wrap items-center gap-4">
+					{#if backgroundUrl}
+						<img src={backgroundUrl} alt="Background preview" class="size-20 rounded-lg border object-cover" />
+					{/if}
+					<label class={cn(buttonVariants({ variant: "outline" }), "cursor-pointer")}>
+						{backgroundFile ? "Replace Image" : "Upload Image"}
+						<input id="backgroundImage" type="file" accept="image/*" onchange={handleBackgroundSelect} hidden />
+					</label>
+					{#if backgroundFile}
+						<Button variant="outline" onclick={clearBackgroundImage}>Remove</Button>
 					{/if}
 				</div>
-				<div class="preview-actions">
-					<button class="btn btn-primary" type="button" onclick={downloadPng}>
-						Download {exportFormat === "png" ? "PNG" : "JPEG"}
-					</button>
-					<button class="btn btn-secondary" type="button" onclick={queueDraw}>Refresh Preview</button>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="mb-6">
+		<Card.Header><Card.Title>Feather &amp; Overlap</Card.Title></Card.Header>
+		<Card.Content class="space-y-4">
+			<div>
+				<Label class="font-normal"><Checkbox bind:checked={featherEnabled} /> Enable Feathering</Label>
+				<p class="text-muted-foreground mt-1 text-sm">Softly blend overlaps without affecting the outer edges.</p>
+			</div>
+			<div>
+				<Label class="font-normal"><Checkbox bind:checked={roundedCorners} /> Rounded Corners</Label>
+				<p class="text-muted-foreground mt-1 text-sm">Smooth corners on each image.</p>
+			</div>
+			<div class="grid gap-3 sm:grid-cols-2">
+				{#if featherEnabled}
+					<div class="grid gap-1.5">
+						<Label for="featherAmount">Feather Strength (px)</Label>
+						<Input id="featherAmount" type="number" min={4} max={120} step={1} bind:value={featherAmount} />
+					</div>
+				{/if}
+				{#if roundedCorners}
+					<div class="grid gap-1.5">
+						<Label for="cornerRadius">Corner Radius (px)</Label>
+						<Input id="cornerRadius" type="number" min={0} max={120} step={1} bind:value={cornerRadius} />
+					</div>
+				{/if}
+			</div>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="mb-6">
+		<Card.Header><Card.Title>Preview</Card.Title></Card.Header>
+		<Card.Content>
+			<div class="grid gap-6 md:grid-cols-[1fr_220px]">
+				<div class="space-y-4">
+					<canvas bind:this={canvasRef} class="bg-muted mx-auto block max-w-full rounded-lg border"></canvas>
+					<div class="flex flex-wrap items-end gap-3">
+						<div class="grid gap-1.5">
+							<Label for="exportFormat">Export Format</Label>
+							<Select id="exportFormat" bind:value={exportFormat} class="w-32">
+								<option value="png">PNG</option>
+								<option value="jpg">JPEG</option>
+							</Select>
+						</div>
+						{#if exportFormat === "jpg"}
+							<div class="grid gap-1.5">
+								<Label for="jpgQuality">JPEG Quality</Label>
+								<Input id="jpgQuality" type="number" min={60} max={100} step={1} bind:value={jpgQuality} class="w-28" />
+							</div>
+						{/if}
+					</div>
+					<div class="flex flex-wrap gap-2">
+						<Button onclick={downloadPng}>
+							<Download class="size-4" />
+							Download {exportFormat === "png" ? "PNG" : "JPEG"}
+						</Button>
+						<Button variant="outline" onclick={queueDraw}>
+							<RefreshCw class="size-4" />
+							Refresh Preview
+						</Button>
+					</div>
+				</div>
+				<div class="text-muted-foreground text-sm">
+					<h3 class="text-foreground mb-2 font-semibold">Quick Tips</h3>
+					<ul class="list-disc space-y-1 pl-4">
+						<li>Grid drops extra images so every row stays even.</li>
+						<li>Masonry auto-fills the canvas and crops when needed.</li>
+						<li>Scattered uses the seed for repeatable layouts.</li>
+					</ul>
 				</div>
 			</div>
-			<div class="preview-info">
-				<h3>Quick Tips</h3>
-				<ul>
-					<li>Grid drops extra images so every row stays even.</li>
-					<li>Masonry auto-fills the canvas and crops when needed.</li>
-					<li>Scattered uses the seed for repeatable layouts.</li>
-				</ul>
-			</div>
-		</div>
-	</section>
+		</Card.Content>
+	</Card.Root>
 </main>
-
-<style>
-	.preview-grid {
-		display: grid;
-		grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-		gap: 1.5rem;
-		align-items: start;
-	}
-
-	.canvas-panel {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	.collage-canvas {
-		width: 100%;
-		height: auto;
-		border-radius: 12px;
-		border: 1px solid rgba(148, 163, 184, 0.35);
-		background: #0f172a;
-	}
-
-	.preview-actions {
-		display: flex;
-		gap: 0.75rem;
-		flex-wrap: wrap;
-	}
-
-	.drop-zone {
-		border: 2px dashed #cbd5e1;
-		border-radius: 16px;
-		padding: 1.5rem;
-		background: #f8fafc;
-		transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-	}
-
-	.drop-zone.has-images {
-		border-color: #a5b4fc;
-		background: #f8fafc;
-	}
-
-	.drop-actions {
-		display: flex;
-		gap: 0.75rem;
-		flex-wrap: wrap;
-		justify-content: center;
-	}
-
-	.bg-upload {
-		display: grid;
-		gap: 0.75rem;
-		padding: 0.75rem;
-		border-radius: 12px;
-		border: 1px solid #e2e8f0;
-		background: #f8fafc;
-	}
-
-	.bg-upload img {
-		width: 100%;
-		max-height: 160px;
-		object-fit: cover;
-		border-radius: 10px;
-		border: 1px solid #e2e8f0;
-	}
-
-	.bg-upload-actions {
-		display: flex;
-		gap: 0.75rem;
-		flex-wrap: wrap;
-	}
-
-	.export-row {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-		gap: 1rem;
-	}
-
-	.slider-group {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.slider-value {
-		min-width: 48px;
-		text-align: right;
-		font-weight: 600;
-		color: #334155;
-	}
-
-	.section-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 1rem;
-	}
-
-	.loading-row {
-		margin-top: 1rem;
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		font-weight: 600;
-		color: #1f2937;
-	}
-
-	.loading-spinner {
-		width: 18px;
-		height: 18px;
-		border-radius: 999px;
-		border: 2px solid #e2e8f0;
-		border-top-color: #007acc;
-		animation: spin 0.8s linear infinite;
-	}
-
-	@keyframes spin {
-		to {
-			transform: rotate(360deg);
-		}
-	}
-
-	.image-grid {
-		margin-top: 0.75rem;
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-		gap: 0.75rem;
-	}
-
-	.image-item {
-		position: relative;
-		border-radius: 12px;
-		overflow: hidden;
-		background: #0f172a;
-		border: 1px solid #e2e8f0;
-		aspect-ratio: 1 / 1;
-	}
-
-	.image-item img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		display: block;
-	}
-
-	.image-number {
-		position: absolute;
-		bottom: 0.5rem;
-		left: 0.5rem;
-		background: rgba(15, 23, 42, 0.85);
-		color: white;
-		padding: 0.2rem 0.5rem;
-		border-radius: 999px;
-		font-size: 0.75rem;
-		font-weight: 600;
-	}
-
-	.image-remove {
-		position: absolute;
-		top: 0.5rem;
-		right: 0.5rem;
-		width: 28px;
-		height: 28px;
-		border-radius: 999px;
-		border: none;
-		background: rgba(15, 23, 42, 0.85);
-		color: white;
-		font-size: 0.9rem;
-		cursor: pointer;
-		display: grid;
-		place-items: center;
-	}
-
-	.image-remove:hover {
-		background: rgba(239, 68, 68, 0.9);
-	}
-
-	.layout-mode-selector {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-		gap: 1rem;
-	}
-
-	.layout-btn {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.25rem;
-		padding: 1rem;
-		background: white;
-		border: 2px solid #e2e8f0;
-		border-radius: 12px;
-		cursor: pointer;
-		transition: all 0.2s;
-	}
-
-	.layout-btn:hover {
-		border-color: #007acc;
-	}
-
-	.layout-btn.active {
-		border-color: #007acc;
-		background: #f0f7ff;
-	}
-
-	.layout-icon {
-		font-size: 1.75rem;
-	}
-
-	.layout-name {
-		font-weight: 600;
-		color: #2d3748;
-	}
-
-	.layout-desc {
-		font-size: 0.8rem;
-		color: #718096;
-		text-align: center;
-	}
-
-	.color-picker-section,
-	.gradient-picker-section {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-		grid-column: 1 / -1;
-	}
-
-	.color-preview-large {
-		width: 100%;
-		height: 120px;
-		border-radius: 8px;
-		border: 1px solid #e2e8f0;
-	}
-
-	.color-controls,
-	.gradient-controls {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.color-input-row {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.color-input-row span {
-		min-width: 60px;
-		font-weight: 500;
-		color: #4a5568;
-	}
-
-	.color-input-row input[type="color"] {
-		width: 40px;
-		height: 40px;
-		border: none;
-		border-radius: 8px;
-		cursor: pointer;
-		padding: 0;
-		background: none;
-	}
-
-	.color-input-row input[type="color"]::-webkit-color-swatch-wrapper {
-		padding: 0;
-	}
-
-	.color-input-row input[type="color"]::-webkit-color-swatch {
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-	}
-
-	.color-hex-input {
-		width: 90px;
-		padding: 0.5rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		font-family: monospace;
-		font-size: 0.9rem;
-	}
-
-	.setting-row {
-		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		gap: 1rem;
-		grid-column: 1 / -1;
-	}
-
-	.mt-2 {
-		margin-top: 1.5rem;
-	}
-
-	.alert {
-		margin-top: 1rem;
-		padding: 0.75rem 1rem;
-		border-radius: 10px;
-		font-size: 0.95rem;
-	}
-
-	.alert-warning {
-		background: rgba(251, 191, 36, 0.2);
-		color: #92400e;
-	}
-
-	.alert-error {
-		background: rgba(248, 113, 113, 0.2);
-		color: #991b1b;
-	}
-
-	.text-warning {
-		color: #b45309;
-		font-weight: 600;
-	}
-
-	.text-success {
-		color: #15803d;
-		font-weight: 600;
-	}
-
-	.progress-row {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.progress-track {
-		flex: 1;
-		height: 8px;
-		border-radius: 999px;
-		background: #e2e8f0;
-		overflow: hidden;
-	}
-
-	.progress-fill {
-		height: 100%;
-		background: linear-gradient(90deg, #38bdf8, #6366f1);
-		border-radius: 999px;
-		transition: width 0.2s ease;
-	}
-
-	.progress-text {
-		min-width: 44px;
-		text-align: right;
-		font-weight: 600;
-		color: #475569;
-	}
-
-	.preview-info ul {
-		padding-left: 1.2rem;
-		margin: 0;
-		color: #475569;
-	}
-
-	.switch {
-		display: flex;
-		gap: 0.5rem;
-		align-items: center;
-		font-weight: 600;
-	}
-
-	@media (max-width: 900px) {
-		.preview-grid {
-			grid-template-columns: 1fr;
-		}
-
-		.setting-row {
-			grid-template-columns: 1fr;
-		}
-	}
-</style>

--- a/src/routes/tools/favicon-extractor/+page.svelte
+++ b/src/routes/tools/favicon-extractor/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
 	import { resolve as resolvePath } from "$app/paths";
 	import { env } from "$env/dynamic/public";
+	import { Button } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Checkbox } from "$lib/components/ui/checkbox";
+	import { Input } from "$lib/components/ui/input";
+	import { cn } from "$lib/utils";
+	import { Globe, LoaderCircle } from "@lucide/svelte";
 	import JSZip from "jszip";
 	import { SvelteMap, SvelteSet } from "svelte/reactivity";
 
@@ -372,227 +378,99 @@
 	<title>Favicon Extractor</title>
 </svelte:head>
 
-<main class="page-container">
-	<a href={resolvePath("/")} class="back-link">← Back to Tools</a>
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
 
-	<h1>🌐 Favicon Extractor</h1>
-	<p class="subtitle">Extract favicon and app icon files from any public website.</p>
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight">
+		<Globe class="text-primary size-7" />
+		Favicon Extractor
+	</h1>
+	<p class="text-muted-foreground mb-8">Extract favicon and app icon files from any public website.</p>
 
-	<section class="card-section">
-		<h2>Website URL</h2>
-		<div class="url-row">
-			<input
-				type="text"
-				bind:value={targetUrl}
-				placeholder="example.com or https://example.com"
-				onkeydown={(event) => {
-					if (event.key === "Enter")
-						void extractFavicons();
-				}}
-			/>
-			<button class="btn btn-primary" type="button" onclick={extractFavicons} disabled={loading || downloading}>
-				{#if loading}
-					<span class="spinner"></span>
-					Scanning...
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Website URL</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<div class="flex flex-col gap-2 sm:flex-row">
+				<Input
+					type="text"
+					bind:value={targetUrl}
+					placeholder="example.com or https://example.com"
+					onkeydown={(event) => {
+						if (event.key === "Enter")
+							void extractFavicons();
+					}}
+				/>
+				<Button class="shrink-0" onclick={extractFavicons} disabled={loading || downloading}>
+					{#if loading}
+						<LoaderCircle class="size-4 animate-spin" />
+						Scanning...
+					{:else}
+						Extract Icons
+					{/if}
+				</Button>
+			</div>
+			{#if loading}
+				{#if scanTotal > 0}
+					<p class="text-muted-foreground mt-3 text-sm">Scanned {scannedCount}/{scanTotal} icon paths...</p>
+					<div class="bg-muted mt-2 h-2 w-full overflow-hidden rounded-full" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={scanProgressPercent}>
+						<div class="bg-primary h-full transition-all" style="width: {scanProgressPercent}%;"></div>
+					</div>
 				{:else}
-					Extract Icons
+					<p class="text-muted-foreground mt-3 text-sm">Discovering icon paths...</p>
 				{/if}
-			</button>
-		</div>
-		{#if loading}
-			{#if scanTotal > 0}
-				<p class="text-muted">Scanned {scannedCount}/{scanTotal} icon paths...</p>
-				<div class="progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={scanProgressPercent}>
-					<div class="progress-fill" style="width: {scanProgressPercent}%;"></div>
-				</div>
-			{:else}
-				<p class="text-muted">Discovering icon paths...</p>
 			{/if}
-		{/if}
-	</section>
+		</Card.Content>
+	</Card.Root>
 
 	{#if error}
-		<div class="error-message">⚠️ {error}</div>
+		<div class="border-destructive/40 bg-destructive/10 text-destructive mb-4 rounded-lg border px-4 py-3 text-sm">⚠️ {error}</div>
 	{/if}
 
 	{#if info && !error}
-		<div class="info-message">✅ {info}</div>
+		<div class="mb-4 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-400">✅ {info}</div>
 	{/if}
 
 	{#if discoveredCount > 0}
-		<section class="card-section">
-			<div class="header-row">
-				<h2>Discovered Icons & Social Images ({discoveredCount})</h2>
-				<div class="header-actions">
-					<button type="button" class="btn" onclick={selectAll}>Select All</button>
-					<button type="button" class="btn" onclick={clearSelection}>Clear</button>
+		<Card.Root>
+			<Card.Header class="flex-row flex-wrap items-center justify-between gap-3 space-y-0">
+				<Card.Title>Discovered Icons & Social Images ({discoveredCount})</Card.Title>
+				<div class="flex flex-wrap gap-2">
+					<Button variant="outline" size="sm" onclick={selectAll}>Select All</Button>
+					<Button variant="outline" size="sm" onclick={clearSelection}>Clear</Button>
 				</div>
-			</div>
+			</Card.Header>
+			<Card.Content>
+				<div class="mb-4 flex flex-wrap gap-2">
+					<Button disabled={selectedCount === 0 || downloading} onclick={() => downloadIcons("selected")}>
+						Download Selected ({selectedCount})
+					</Button>
+					<Button variant="outline" disabled={discoveredCount === 0 || downloading} onclick={() => downloadIcons("all")}>
+						Download All
+					</Button>
+				</div>
 
-			<div class="action-row">
-				<button
-					type="button"
-					class="btn btn-primary"
-					disabled={selectedCount === 0 || downloading}
-					onclick={() => downloadIcons("selected")}
-				>
-					Download Selected ({selectedCount})
-				</button>
-				<button
-					type="button"
-					class="btn"
-					disabled={discoveredCount === 0 || downloading}
-					onclick={() => downloadIcons("all")}
-				>
-					Download All
-				</button>
-			</div>
-
-			<div class="icon-grid">
-				{#each icons as icon (icon.id)}
-					<article class="icon-card" class:selected={icon.selected}>
-						<label class="icon-header">
-							<input type="checkbox" checked={icon.selected} onchange={() => toggleSelect(icon.id)} />
-							<span>{icon.width}×{icon.height}</span>
-							<span class="text-muted">{icon.type}</span>
-						</label>
-						<div class="preview-wrap" class:social={icon.category === "social"}>
-							<img src={icon.fetchUrl} alt="Icon preview" loading="lazy" />
-						</div>
-						<div class="icon-meta text-muted">
-							<span>{icon.source}</span>
-							<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-							<a href={icon.url} target="_blank" rel="noopener noreferrer">Open URL ↗</a>
-						</div>
-					</article>
-				{/each}
-			</div>
-		</section>
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(190px,1fr))] gap-3">
+					{#each icons as icon (icon.id)}
+						<article class={cn("bg-card flex flex-col gap-2.5 rounded-lg border p-3", icon.selected ? "border-primary ring-primary/20 ring-2" : "border-border")}>
+							<label class="grid grid-cols-[auto_1fr_auto] items-center gap-2 text-sm">
+								<Checkbox checked={icon.selected} onCheckedChange={() => toggleSelect(icon.id)} />
+								<span>{icon.width}×{icon.height}</span>
+								<span class="text-muted-foreground">{icon.type}</span>
+							</label>
+							<div class={cn("bg-muted grid place-items-center rounded-md border", icon.category === "social" ? "h-28" : "h-20")}>
+								<img src={icon.fetchUrl} alt="Icon preview" loading="lazy" class={cn("object-contain", icon.category === "social" ? "max-h-24 max-w-full" : "max-h-[72px] max-w-[72px]")} />
+							</div>
+							<div class="text-muted-foreground flex items-center justify-between gap-2 text-xs">
+								<span>{icon.source}</span>
+								<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+								<a href={icon.url} class="hover:text-foreground" target="_blank" rel="noopener noreferrer">Open URL ↗</a>
+							</div>
+						</article>
+					{/each}
+				</div>
+			</Card.Content>
+		</Card.Root>
 	{/if}
 </main>
-
-<style>
-	.url-row {
-		display: grid;
-		grid-template-columns: 1fr auto;
-		gap: 0.75rem;
-	}
-
-	.info-message {
-		background: #e6fffa;
-		color: #0f766e;
-		padding: 0.8rem 1rem;
-		border-radius: 8px;
-		margin-bottom: 1rem;
-	}
-
-	.progress-track {
-		width: 100%;
-		height: 8px;
-		margin-top: 0.5rem;
-		border-radius: 999px;
-		background: #e2e8f0;
-		overflow: hidden;
-	}
-
-	.progress-fill {
-		height: 100%;
-		background: linear-gradient(90deg, #14b8a6, #0ea5e9);
-		transition: width 0.2s ease;
-	}
-
-	.header-row {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 1rem;
-		margin-bottom: 1rem;
-	}
-
-	.header-row h2 {
-		margin: 0;
-	}
-
-	.header-actions,
-	.action-row {
-		display: flex;
-		gap: 0.5rem;
-		flex-wrap: wrap;
-	}
-
-	.action-row {
-		margin-bottom: 1rem;
-	}
-
-	.icon-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
-		gap: 0.75rem;
-	}
-
-	.icon-card {
-		border: 1px solid #e2e8f0;
-		border-radius: 10px;
-		padding: 0.75rem;
-		background: white;
-		display: flex;
-		flex-direction: column;
-		gap: 0.6rem;
-	}
-
-	.icon-card.selected {
-		border-color: #007acc;
-		box-shadow: 0 0 0 2px rgba(0, 122, 204, 0.12);
-	}
-
-	.icon-header {
-		display: grid;
-		grid-template-columns: auto 1fr auto;
-		align-items: center;
-		gap: 0.5rem;
-		font-size: 0.85rem;
-	}
-
-	.preview-wrap {
-		height: 84px;
-		border-radius: 8px;
-		background: #f8fafc;
-		border: 1px solid #e2e8f0;
-		display: grid;
-		place-items: center;
-	}
-
-	.preview-wrap img {
-		max-width: 72px;
-		max-height: 72px;
-		object-fit: contain;
-	}
-
-	.preview-wrap.social {
-		height: 110px;
-	}
-
-	.preview-wrap.social img {
-		max-width: 100%;
-		max-height: 96px;
-	}
-
-	.icon-meta {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 0.5rem;
-		font-size: 0.8rem;
-	}
-
-	@media (max-width: 700px) {
-		.url-row {
-			grid-template-columns: 1fr;
-		}
-
-		.header-row {
-			align-items: flex-start;
-			flex-direction: column;
-		}
-	}
-</style>

--- a/src/routes/tools/image-compressor/+page.svelte
+++ b/src/routes/tools/image-compressor/+page.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
 	import { resolve as resolvePath } from "$app/paths";
+	import { Button } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Checkbox } from "$lib/components/ui/checkbox";
+	import { Input } from "$lib/components/ui/input";
+	import { Label } from "$lib/components/ui/label";
+	import { Select } from "$lib/components/ui/select";
+	import { Slider } from "$lib/components/ui/slider";
+	import { cn } from "$lib/utils";
+	import { LoaderCircle, Package, Shrink, Upload } from "@lucide/svelte";
 	import JSZip from "jszip";
 	import { onDestroy } from "svelte";
 
@@ -299,456 +308,229 @@
 	<title>Batch Image Compressor</title>
 </svelte:head>
 
-<main class="page-container">
-	<a href={resolvePath("/")} class="back-link">← Back to Tools</a>
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
 
-	<h1>🗜️ Batch Image Compressor</h1>
-	<p class="subtitle">Resize, convert, and compress multiple images in one pass.</p>
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight">
+		<Shrink class="text-primary size-7" />
+		Batch Image Compressor
+	</h1>
+	<p class="text-muted-foreground mb-8">Resize, convert, and compress multiple images in one pass.</p>
 
-	<section class="card-section">
-		<h2>Upload Images</h2>
-		<div
-			class="drop-zone"
-			class:has-file={sourceImages.length > 0}
-			ondrop={handleDrop}
-			ondragover={handleDragOver}
-			role="button"
-			tabindex="0"
-		>
-			<div class="drop-content">
-				<span class="upload-icon">🖼️</span>
-				<p>Drag & drop image files</p>
-				<p class="text-muted">or</p>
-				<label class="btn btn-primary">
-					Browse Images
-					<input type="file" accept="image/*" multiple onchange={handleSelect} hidden />
-				</label>
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Upload Images</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<label
+				class="border-input hover:border-ring hover:bg-accent bg-muted/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
+				ondrop={handleDrop}
+				ondragover={handleDragOver}
+			>
+				<Upload class="text-muted-foreground size-9" />
+				<p class="font-medium">Drag & drop image files</p>
+				<p class="text-muted-foreground text-sm">or click to browse</p>
 				{#if sourceImages.length > 0}
-					<p class="text-muted">{sourceImages.length} image{sourceImages.length === 1 ? "" : "s"} loaded</p>
+					<p class="text-muted-foreground text-sm">{sourceImages.length} image{sourceImages.length === 1 ? "" : "s"} loaded</p>
+				{/if}
+				<input type="file" accept="image/*" multiple onchange={handleSelect} hidden />
+			</label>
+			{#if sourceImages.length > 0}
+				<div class="mt-3">
+					<Button variant="outline" size="sm" onclick={clearAll}>Clear All</Button>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Compression Settings</Card.Title>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="grid gap-1.5">
+				<Label>Resize Mode</Label>
+				<div class="bg-muted inline-flex flex-wrap gap-1 rounded-lg p-1">
+					<Button variant={resizeMode === "fit-box" ? "default" : "ghost"} size="sm" onclick={() => (resizeMode = "fit-box")}>Fit Within Box</Button>
+					<Button variant={resizeMode === "target-width" ? "default" : "ghost"} size="sm" onclick={() => (resizeMode = "target-width")}>Target Width</Button>
+					<Button variant={resizeMode === "target-height" ? "default" : "ghost"} size="sm" onclick={() => (resizeMode = "target-height")}>Target Height</Button>
+				</div>
+			</div>
+			<div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+				<div class="grid gap-1.5">
+					<Label for="format">Output Format</Label>
+					<Select id="format" bind:value={outputFormat}>
+						{#each formatOptions as option (option.value)}
+							<option value={option.value}>{option.label}</option>
+						{/each}
+					</Select>
+				</div>
+				{#if resizeMode !== "target-height"}
+					<div class="grid gap-1.5">
+						<Label for="maxWidth">{resizeMode === "target-width" ? "Target Width (px)" : "Max Width (px)"}</Label>
+						<Input id="maxWidth" type="number" min={64} max={12000} bind:value={maxWidth} />
+					</div>
+				{/if}
+				{#if resizeMode !== "target-width"}
+					<div class="grid gap-1.5">
+						<Label for="maxHeight">{resizeMode === "target-height" ? "Target Height (px)" : "Max Height (px)"}</Label>
+						<Input id="maxHeight" type="number" min={64} max={12000} bind:value={maxHeight} />
+					</div>
+				{/if}
+				{#if outputFormat !== "png"}
+					<div class="grid gap-1.5">
+						<Label for="quality">Quality ({quality}%)</Label>
+						<div class="flex h-9 items-center"><Slider type="single" min={1} max={100} bind:value={quality} /></div>
+					</div>
 				{/if}
 			</div>
-		</div>
-		{#if sourceImages.length > 0}
-			<div class="section-actions">
-				<button type="button" class="btn" onclick={clearAll}>Clear All</button>
-			</div>
-		{/if}
-	</section>
-
-	<section class="card-section">
-		<h2>Compression Settings</h2>
-		<div class="mode-row">
-			<span class="mode-label">Resize Mode</span>
-			<div class="mode-buttons">
-				<button type="button" class="btn mode-btn" class:active={resizeMode === "fit-box"} onclick={() => {
-					resizeMode = "fit-box";
-				}}>
-					Fit Within Box
-				</button>
-				<button type="button" class="btn mode-btn" class:active={resizeMode === "target-width"} onclick={() => {
-					resizeMode = "target-width";
-				}}>
-					Target Width
-				</button>
-				<button type="button" class="btn mode-btn" class:active={resizeMode === "target-height"} onclick={() => {
-					resizeMode = "target-height";
-				}}>
-					Target Height
-				</button>
-			</div>
-		</div>
-		<div class="settings-grid">
-			<div class="setting-group">
-				<label for="format">Output Format</label>
-				<select id="format" bind:value={outputFormat}>
-					{#each formatOptions as option (option.value)}
-						<option value={option.value}>{option.label}</option>
-					{/each}
-				</select>
-			</div>
-			{#if resizeMode !== "target-height"}
-				<div class="setting-group">
-					<label for="maxWidth">{resizeMode === "target-width" ? "Target Width (px)" : "Max Width (px)"}</label>
-					<input id="maxWidth" type="number" min="64" max="12000" bind:value={maxWidth} />
-				</div>
-			{/if}
-			{#if resizeMode !== "target-width"}
-				<div class="setting-group">
-					<label for="maxHeight">{resizeMode === "target-height" ? "Target Height (px)" : "Max Height (px)"}</label>
-					<input id="maxHeight" type="number" min="64" max="12000" bind:value={maxHeight} />
-				</div>
-			{/if}
-			{#if outputFormat !== "png"}
-				<div class="setting-group">
-					<label for="quality">Quality ({quality}%)</label>
-					<input id="quality" type="range" min="1" max="100" bind:value={quality} />
-				</div>
-			{/if}
-		</div>
-		<p class="text-muted">
-			{#if resizeMode === "fit-box"}
-				Images are resized to fit inside max width/height while preserving aspect ratio.
-			{:else if resizeMode === "target-width"}
-				Width is fixed and height is auto-scaled to preserve aspect ratio.
-			{:else}
-				Height is fixed and width is auto-scaled to preserve aspect ratio.
-			{/if}
-		</p>
-		<label class="checkbox-label">
-			<input type="checkbox" bind:checked={preventUpscale} />
-			<span>Prevent upscaling small images</span>
-		</label>
-		<p class="text-muted">Metadata is stripped during export when images are re-encoded.</p>
-	</section>
+			<p class="text-muted-foreground text-sm">
+				{#if resizeMode === "fit-box"}
+					Images are resized to fit inside max width/height while preserving aspect ratio.
+				{:else if resizeMode === "target-width"}
+					Width is fixed and height is auto-scaled to preserve aspect ratio.
+				{:else}
+					Height is fixed and width is auto-scaled to preserve aspect ratio.
+				{/if}
+			</p>
+			<Label class="font-normal"><Checkbox bind:checked={preventUpscale} /> Prevent upscaling small images</Label>
+			<p class="text-muted-foreground text-sm">Metadata is stripped during export when images are re-encoded.</p>
+		</Card.Content>
+	</Card.Root>
 
 	{#if error}
-		<div class="error-message">⚠️ {error}</div>
+		<div class="border-destructive/40 bg-destructive/10 text-destructive mb-4 rounded-lg border px-4 py-3 text-sm">⚠️ {error}</div>
 	{/if}
 
-	<section class="text-center mb-3">
-		<button class="btn btn-primary btn-large" onclick={processImages} disabled={!canProcess}>
+	<div class="mb-6 text-center">
+		<Button size="lg" onclick={processImages} disabled={!canProcess}>
 			{#if processing}
-				<span class="spinner"></span>
+				<LoaderCircle class="size-4 animate-spin" />
 				Processing {processedCount}/{sourceImages.length}...
 			{:else}
-				🚀 Compress Images
+				Compress Images
 			{/if}
-		</button>
-	</section>
+		</Button>
+	</div>
 
 	{#if sourceImages.length > 0 || hasResults || processing}
-		<section class="card-section status-panel" aria-live="polite">
-			<div class="status-header">
-				<h2>Compression Status</h2>
-				<span class="status-pill" class:status-ready={hasResults && !processing} class:status-active={processing}>
-					{#if processing}
-						Processing
-					{:else if hasResults}
-						Ready
-					{:else}
-						Waiting
-					{/if}
+		<Card.Root class="mb-6" aria-live="polite">
+			<Card.Header class="flex-row items-center justify-between space-y-0">
+				<Card.Title>Compression Status</Card.Title>
+				<span class={cn(
+					"rounded-full px-2.5 py-0.5 text-xs font-medium",
+					processing ? "bg-amber-500/15 text-amber-600 dark:text-amber-400" : hasResults ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400" : "bg-muted text-muted-foreground",
+				)}>
+					{#if processing}Processing{:else if hasResults}Ready{:else}Waiting{/if}
 				</span>
-			</div>
-			{#if processing}
-				<p class="status-text">Processing {processedCount} of {sourceImages.length} images...</p>
-			{:else if hasResults}
-				<p class="status-text">Complete: {processedImages.length} files are ready for download.</p>
-			{:else}
-				<p class="status-text">Adjust settings and run compression.</p>
-			{/if}
-			<div class="progress-track">
-				<div class="progress-fill" style="width: {processing ? progressPercent : hasResults ? 100 : 0}%;"></div>
-			</div>
-			<div class="progress-meta text-muted">
-				<span>{processing ? `${progressPercent}%` : hasResults ? "100%" : "0%"}</span>
-				{#if hasResults}
-					<span>{formatBytes(originalTotalBytes)} → {formatBytes(processedTotalBytes)}</span>
+			</Card.Header>
+			<Card.Content>
+				{#if processing}
+					<p class="mb-2 text-sm">Processing {processedCount} of {sourceImages.length} images...</p>
+				{:else if hasResults}
+					<p class="mb-2 text-sm">Complete: {processedImages.length} files are ready for download.</p>
+				{:else}
+					<p class="text-muted-foreground mb-2 text-sm">Adjust settings and run compression.</p>
 				{/if}
-			</div>
-			{#if hasResults}
-				<div class="status-actions">
-					<button class="btn btn-primary" type="button" onclick={downloadZip} disabled={processing}>
-						📦 Download ZIP
-					</button>
-					<a href="#results" class="btn btn-link">View Previews ↓</a>
+				<div class="bg-muted h-2 w-full overflow-hidden rounded-full">
+					<div class="bg-primary h-full transition-all" style="width: {processing ? progressPercent : hasResults ? 100 : 0}%;"></div>
 				</div>
-			{/if}
-		</section>
+				<div class="text-muted-foreground mt-1.5 flex justify-between text-xs">
+					<span>{processing ? `${progressPercent}%` : hasResults ? "100%" : "0%"}</span>
+					{#if hasResults}
+						<span>{formatBytes(originalTotalBytes)} → {formatBytes(processedTotalBytes)}</span>
+					{/if}
+				</div>
+				{#if hasResults}
+					<div class="mt-4 flex flex-wrap items-center gap-2">
+						<Button onclick={downloadZip} disabled={processing}>
+							<Package class="size-4" />
+							Download ZIP
+						</Button>
+						<Button variant="link" onclick={() => document.getElementById("results")?.scrollIntoView({ behavior: "smooth" })}>View Previews ↓</Button>
+					</div>
+				{/if}
+			</Card.Content>
+		</Card.Root>
 	{/if}
 
 	{#if sourceImages.length > 0 && !processing && !hasResults}
-		<section class="card-section">
-			<h2>Source Files</h2>
-			<div class="stats-grid">
-				<div class="stat-card">
-					<span class="stat-label">Total Source Size</span>
-					<strong>{formatBytes(originalTotalBytes)}</strong>
-				</div>
-				<div class="stat-card">
-					<span class="stat-label">Target Limit</span>
-					<strong>{maxWidth} × {maxHeight}px</strong>
-				</div>
-			</div>
-			<div class="image-grid">
-				{#each sourceImages as item, index (item.previewUrl)}
-					<div class="image-item">
-						<img src={item.previewUrl} alt="Source image {index + 1}" loading="lazy" />
-						<div class="image-meta">
-							<span>{item.width} × {item.height}px</span>
-							<span>{formatBytes(item.file.size)}</span>
-						</div>
+		<Card.Root class="mb-6">
+			<Card.Header>
+				<Card.Title>Source Files</Card.Title>
+			</Card.Header>
+			<Card.Content class="space-y-4">
+				<div class="grid grid-cols-2 gap-3">
+					<div class="bg-muted flex flex-col gap-1 rounded-lg border p-3">
+						<span class="text-muted-foreground text-xs">Total Source Size</span>
+						<strong>{formatBytes(originalTotalBytes)}</strong>
 					</div>
-				{/each}
-			</div>
-		</section>
+					<div class="bg-muted flex flex-col gap-1 rounded-lg border p-3">
+						<span class="text-muted-foreground text-xs">Target Limit</span>
+						<strong>{maxWidth} × {maxHeight}px</strong>
+					</div>
+				</div>
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+					{#each sourceImages as item, index (item.previewUrl)}
+						<div class="overflow-hidden rounded-md border">
+							<img src={item.previewUrl} alt="Source image {index + 1}" loading="lazy" class="aspect-square w-full object-cover" />
+							<div class="text-muted-foreground flex flex-col gap-0.5 p-2 text-xs">
+								<span>{item.width} × {item.height}px</span>
+								<span>{formatBytes(item.file.size)}</span>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</Card.Content>
+		</Card.Root>
 	{/if}
 
 	{#if hasResults}
-		<section class="card-section" id="results">
-			<h2>Results</h2>
-			<div class="stats-grid">
-				<div class="stat-card">
-					<span class="stat-label">Compressed Size</span>
-					<strong>{formatBytes(processedTotalBytes)}</strong>
-				</div>
-				<div class="stat-card">
-					<span class="stat-label">Change</span>
-					<strong class:positive={sizeDeltaPercent > 0} class:negative={sizeDeltaPercent <= 0}>
-						{sizeDeltaPercent > 0 ? "+" : ""}{sizeDeltaPercent.toFixed(1)}%
-					</strong>
-				</div>
-				<div class="stat-card">
-					<span class="stat-label">Output Files</span>
-					<strong>{processedImages.length} {activeFormat.label}</strong>
-				</div>
-			</div>
-
-			<div class="image-grid">
-				{#each processedImages as item, index (item.previewUrl)}
-					<div class="image-item">
-						<img src={item.previewUrl} alt="Compressed image {index + 1}" loading="lazy" />
-						<div class="image-meta">
-							<span>{item.width} × {item.height}px</span>
-							<span>{formatBytes(item.blob.size)}</span>
-						</div>
+		<Card.Root class="mb-6" id="results">
+			<Card.Header>
+				<Card.Title>Results</Card.Title>
+			</Card.Header>
+			<Card.Content class="space-y-4">
+				<div class="grid grid-cols-3 gap-3">
+					<div class="bg-muted flex flex-col gap-1 rounded-lg border p-3">
+						<span class="text-muted-foreground text-xs">Compressed Size</span>
+						<strong>{formatBytes(processedTotalBytes)}</strong>
 					</div>
-				{/each}
-			</div>
+					<div class="bg-muted flex flex-col gap-1 rounded-lg border p-3">
+						<span class="text-muted-foreground text-xs">Change</span>
+						<strong class={sizeDeltaPercent > 0 ? "text-destructive" : "text-emerald-600 dark:text-emerald-400"}>
+							{sizeDeltaPercent > 0 ? "+" : ""}{sizeDeltaPercent.toFixed(1)}%
+						</strong>
+					</div>
+					<div class="bg-muted flex flex-col gap-1 rounded-lg border p-3">
+						<span class="text-muted-foreground text-xs">Output Files</span>
+						<strong>{processedImages.length} {activeFormat.label}</strong>
+					</div>
+				</div>
 
-			<div class="text-center mt-2">
-				<button class="btn btn-primary btn-large" type="button" onclick={downloadZip} disabled={processing}>
-					📦 Download ZIP
-				</button>
-			</div>
-		</section>
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+					{#each processedImages as item, index (item.previewUrl)}
+						<div class="overflow-hidden rounded-md border">
+							<img src={item.previewUrl} alt="Compressed image {index + 1}" loading="lazy" class="aspect-square w-full object-cover" />
+							<div class="text-muted-foreground flex flex-col gap-0.5 p-2 text-xs">
+								<span>{item.width} × {item.height}px</span>
+								<span>{formatBytes(item.blob.size)}</span>
+							</div>
+						</div>
+					{/each}
+				</div>
+
+				<div class="text-center">
+					<Button size="lg" onclick={downloadZip} disabled={processing}>
+						<Package class="size-4" />
+						Download ZIP
+					</Button>
+				</div>
+			</Card.Content>
+		</Card.Root>
 	{/if}
 
-	<footer class="text-center text-muted">
+	<footer class="text-muted-foreground text-center text-sm">
 		<p>✨ Runs in your browser • No uploads required</p>
 	</footer>
 </main>
-
-<style>
-	.drop-content {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.upload-icon {
-		font-size: 3rem;
-	}
-
-	.settings-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-		gap: 1rem;
-		margin-bottom: 1rem;
-	}
-
-	.mode-row {
-		display: flex;
-		flex-direction: column;
-		gap: 0.6rem;
-		margin-bottom: 1rem;
-	}
-
-	.mode-label {
-		font-size: 0.85rem;
-		font-weight: 500;
-		color: #4a5568;
-	}
-
-	.mode-buttons {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-	}
-
-	.mode-btn {
-		background: white;
-		border: 1px solid #e2e8f0;
-		color: #4a5568;
-		padding: 0.5rem 0.9rem;
-	}
-
-	.mode-btn:hover {
-		border-color: #007acc;
-		color: #007acc;
-	}
-
-	.mode-btn.active {
-		background: #007acc;
-		border-color: #007acc;
-		color: white;
-	}
-
-	.setting-group {
-		display: flex;
-		flex-direction: column;
-		gap: 0.4rem;
-	}
-
-	.section-actions {
-		margin-top: 1rem;
-		display: flex;
-		justify-content: flex-end;
-	}
-
-	.status-panel {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.status-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 1rem;
-	}
-
-	.status-header h2 {
-		margin: 0;
-	}
-
-	.status-pill {
-		font-size: 0.75rem;
-		font-weight: 600;
-		padding: 0.25rem 0.6rem;
-		border-radius: 999px;
-		color: #4a5568;
-		background: #edf2f7;
-	}
-
-	.status-pill.status-active {
-		background: #e6fffa;
-		color: #0f766e;
-	}
-
-	.status-pill.status-ready {
-		background: #f0fff4;
-		color: #276749;
-	}
-
-	.status-text {
-		margin: 0;
-	}
-
-	.progress-track {
-		height: 10px;
-		border-radius: 999px;
-		background: #e2e8f0;
-		overflow: hidden;
-	}
-
-	.progress-fill {
-		height: 100%;
-		background: linear-gradient(90deg, #38b2ac, #2b6cb0);
-		transition: width 0.2s ease;
-	}
-
-	.progress-meta {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 1rem;
-		font-size: 0.85rem;
-	}
-
-	.status-actions {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.75rem;
-	}
-
-	.btn-link {
-		text-decoration: none;
-		background: #edf2f7;
-		color: #2d3748;
-	}
-
-	.btn-link:hover {
-		background: #e2e8f0;
-	}
-
-	.checkbox-label {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-bottom: 0.5rem;
-	}
-
-	.stats-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-		gap: 0.75rem;
-		margin-bottom: 1rem;
-	}
-
-	.stat-card {
-		background: #fff;
-		border: 1px solid #e2e8f0;
-		border-radius: 10px;
-		padding: 0.75rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.3rem;
-	}
-
-	.stat-label {
-		color: #718096;
-		font-size: 0.8rem;
-	}
-
-	.positive {
-		color: #c05621;
-	}
-
-	.negative {
-		color: #2f855a;
-	}
-
-	.image-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-		gap: 0.75rem;
-	}
-
-	.image-item {
-		border: 1px solid #e2e8f0;
-		border-radius: 10px;
-		overflow: hidden;
-		background: white;
-	}
-
-	.image-item img {
-		display: block;
-		width: 100%;
-		height: 120px;
-		object-fit: cover;
-	}
-
-	.image-meta {
-		display: flex;
-		flex-direction: column;
-		padding: 0.5rem;
-		gap: 0.2rem;
-		font-size: 0.8rem;
-		color: #4a5568;
-	}
-
-	.btn-large {
-		padding: 1rem 2rem;
-		font-size: 1.1rem;
-	}
-
-	@media (max-width: 600px) {
-		.progress-meta {
-			flex-direction: column;
-			align-items: flex-start;
-		}
-	}
-</style>

--- a/src/routes/tools/instagram-carousel/+page.svelte
+++ b/src/routes/tools/instagram-carousel/+page.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
 	import { resolve as resolvePath } from "$app/paths";
+	import { Button } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Checkbox } from "$lib/components/ui/checkbox";
+	import { Input } from "$lib/components/ui/input";
+	import { Label } from "$lib/components/ui/label";
+	import { Slider } from "$lib/components/ui/slider";
+	import { cn } from "$lib/utils";
+	import { Blend, Eye, Image as ImageIcon, Images, LoaderCircle, Package, Palette, Shuffle, Upload, X } from "@lucide/svelte";
 	import JSZip from "jszip";
 
 	// Resolution settings
@@ -679,298 +687,158 @@
 	<title>Instagram Carousel Creator</title>
 </svelte:head>
 
-<main class="page-container">
-	<a href={resolvePath("/")} class="back-link">← Back to Tools</a>
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
 
-	<h1>📸 Instagram Carousel Creator</h1>
-	<p class="subtitle">Create carousel images with a consistent background</p>
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight"><Images class="text-primary size-7" /> Instagram Carousel Creator</h1>
+	<p class="text-muted-foreground mb-8">Create carousel images with a consistent background</p>
 
-	<!-- Resolution Settings -->
-	<section class="card-section">
-		<h2>Output Resolution</h2>
-		<div class="resolution-controls">
-			<div class="presets">
+	<Card.Root class="mb-6">
+		<Card.Header><Card.Title>Output Resolution</Card.Title></Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="flex flex-wrap gap-2">
 				{#each presets as preset (preset.name)}
-					<button
-						type="button"
-						class="btn preset-btn"
-						class:active={width === preset.width && height === preset.height}
-						onclick={() => applyPreset(preset)}
-					>
-						{preset.name}
-					</button>
+					<Button variant={width === preset.width && height === preset.height ? "default" : "outline"} size="sm" onclick={() => applyPreset(preset)}>{preset.name}</Button>
 				{/each}
 			</div>
-			<div class="custom-size">
-				<div class="size-input">
-					<label for="width">Width</label>
-					<input id="width" type="number" bind:value={width} min="100" max="4096" onchange={clearPreviews} />
-				</div>
-				<span class="size-separator">×</span>
-				<div class="size-input">
-					<label for="height">Height</label>
-					<input id="height" type="number" bind:value={height} min="100" max="4096" onchange={clearPreviews} />
-				</div>
+			<div class="flex items-end gap-3">
+				<div class="grid gap-1.5"><Label for="width">Width</Label><Input id="width" type="number" bind:value={width} min={100} max={4096} onchange={clearPreviews} /></div>
+				<span class="text-muted-foreground pb-2">×</span>
+				<div class="grid gap-1.5"><Label for="height">Height</Label><Input id="height" type="number" bind:value={height} min={100} max={4096} onchange={clearPreviews} /></div>
 			</div>
-		</div>
-	</section>
+		</Card.Content>
+	</Card.Root>
 
-	<!-- Background -->
-	<section class="card-section">
-		<h2>Background</h2>
-
-		<!-- Background type selector -->
-		<div class="bg-type-selector">
-			<button
-				type="button"
-				class="btn bg-type-btn"
-				class:active={backgroundType === "image"}
-				onclick={() => {
+	<Card.Root class="mb-6">
+		<Card.Header><Card.Title>Background</Card.Title></Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="flex flex-wrap gap-2">
+				<Button variant={backgroundType === "image" ? "default" : "outline"} size="sm" onclick={() => {
 					backgroundType = "image";
 					clearPreviews();
-				}}
-			>
-				🖼️ Image
-			</button>
-			<button
-				type="button"
-				class="btn bg-type-btn"
-				class:active={backgroundType === "color"}
-				onclick={() => {
+				}}><ImageIcon class="size-4" /> Image</Button>
+				<Button variant={backgroundType === "color" ? "default" : "outline"} size="sm" onclick={() => {
 					backgroundType = "color";
 					clearPreviews();
-				}}
-			>
-				🎨 Solid Color
-			</button>
-			<button
-				type="button"
-				class="btn bg-type-btn"
-				class:active={backgroundType === "gradient"}
-				onclick={() => {
+				}}><Palette class="size-4" /> Solid Color</Button>
+				<Button variant={backgroundType === "gradient" ? "default" : "outline"} size="sm" onclick={() => {
 					backgroundType = "gradient";
 					clearPreviews();
-				}}
-			>
-				🌈 Gradient
-			</button>
-		</div>
+				}}><Blend class="size-4" /> Gradient</Button>
+			</div>
 
-		<!-- Image background -->
-		{#if backgroundType === "image"}
-			<div
-				class="drop-zone"
-				class:has-file={backgroundFile}
-				ondrop={handleBackgroundDrop}
-				ondragover={handleDragOver}
-				role="button"
-				tabindex="0"
-			>
+			{#if backgroundType === "image"}
 				{#if backgroundPreview}
-					<div class="background-preview">
-						<img src={backgroundPreview} alt="Background preview" />
-						<div class="preview-overlay">
-							<button type="button" class="remove-btn" onclick={clearBackground}>✕</button>
-						</div>
+					<div class="relative overflow-hidden rounded-lg border">
+						<img src={backgroundPreview} alt="Background preview" class="max-h-64 w-full object-contain" />
+						<Button variant="destructive" size="icon" class="absolute top-2 right-2 size-8" onclick={clearBackground}><X class="size-4" /></Button>
 					</div>
 				{:else}
-					<div class="drop-content">
-						<span class="upload-icon">🖼️</span>
-						<p>Drag & drop a background image</p>
-						<p class="text-muted">or</p>
-						<label class="btn btn-primary">
-							Browse Files
-							<input type="file" accept="image/*" onchange={handleBackgroundSelect} hidden />
-						</label>
-					</div>
+					<label
+						class="border-input hover:border-ring hover:bg-accent bg-muted/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
+						ondrop={handleBackgroundDrop}
+						ondragover={handleDragOver}
+					>
+						<Upload class="text-muted-foreground size-9" />
+						<p class="font-medium">Drag & drop a background image</p>
+						<p class="text-muted-foreground text-sm">or click to browse</p>
+						<input type="file" accept="image/*" onchange={handleBackgroundSelect} hidden />
+					</label>
 				{/if}
-			</div>
 
-			{#if backgroundFile}
-				<div class="bg-mode-selector">
-					<span class="mode-label">Background Position:</span>
-					<div class="mode-buttons">
-						{#each bgModes as mode (mode.value)}
-							<button
-								type="button"
-								class="btn mode-btn"
-								class:active={backgroundMode === mode.value}
-								onclick={() => {
+				{#if backgroundFile}
+					<div class="grid gap-1.5">
+						<Label>Background Position</Label>
+						<div class="flex flex-wrap gap-2">
+							{#each bgModes as mode (mode.value)}
+								<Button variant={backgroundMode === mode.value ? "default" : "outline"} size="sm" onclick={() => {
 									backgroundMode = mode.value;
 									clearPreviews();
-								}}
-								title={mode.desc}
-							>
-								{mode.label}
-							</button>
-						{/each}
+								}} title={mode.desc}>{mode.label}</Button>
+							{/each}
+						</div>
 					</div>
-				</div>
 
-				{#if backgroundUpscaled()}
-					{@const info = backgroundUpscaled()}
-					<div class="upscale-warning">
-						<span class="warning-icon">⚠️</span>
-						<span>
-							Background image will be upscaled ({info?.originalWidth}×{info?.originalHeight}), which may appear blurry.
-						</span>
-					</div>
+					{#if backgroundUpscaled()}
+						{@const info = backgroundUpscaled()}
+						<div class="flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
+							<span>⚠️</span>
+							<span>Background image will be upscaled ({info?.originalWidth}×{info?.originalHeight}), which may appear blurry.</span>
+						</div>
+					{/if}
 				{/if}
 			{/if}
-		{/if}
 
-		<!-- Solid color background -->
-		{#if backgroundType === "color"}
-			<div class="color-picker-section">
-				<div class="color-preview-large" style="background: {bgColor};"></div>
-				<div class="color-controls">
-					<label class="color-input-row">
-						<span>Color</span>
-						<input
-							type="color"
-							bind:value={bgColor}
-							onchange={clearPreviews}
-						/>
-						<input
-							type="text"
-							bind:value={bgColor}
-							onchange={clearPreviews}
-							class="color-hex-input"
-							pattern="^#[0-9A-Fa-f]{6}$"
-						/>
-					</label>
+			{#if backgroundType === "color"}
+				<div class="flex flex-wrap items-center gap-4">
+					<div class="size-16 shrink-0 rounded-lg border" style="background: {bgColor};"></div>
+					<div class="flex items-center gap-2">
+						<input type="color" bind:value={bgColor} onchange={clearPreviews} class="border-input size-9 shrink-0 cursor-pointer rounded-md border bg-transparent p-1" />
+						<Input type="text" bind:value={bgColor} onchange={clearPreviews} class="w-28 font-mono" pattern="^#[0-9A-Fa-f]{6}$" />
+					</div>
 				</div>
-				<div class="color-presets">
+				<div class="flex flex-wrap gap-2">
 					{#each ["#1a1a2e", "#16213e", "#0f3460", "#533483", "#e94560", "#f5f5f5", "#2d3436", "#000000"] as preset (preset)}
-						<button
-							type="button"
-							class="color-preset"
-							style="background: {preset};"
-							onclick={() => {
-								bgColor = preset;
-								clearPreviews();
-							}}
-							title={preset}
-						></button>
+						<button type="button" class="border-border size-8 rounded-md border" style="background: {preset};" onclick={() => {
+							bgColor = preset;
+							clearPreviews();
+						}} title={preset} aria-label={preset}></button>
 					{/each}
 				</div>
-			</div>
-		{/if}
+			{/if}
 
-		<!-- Gradient background -->
-		{#if backgroundType === "gradient"}
-			<div class="gradient-picker-section">
+			{#if backgroundType === "gradient"}
 				<div
-					class="color-preview-large"
+					class="h-24 w-full rounded-lg border"
 					style="background: {gradientType === "linear"
 						? `linear-gradient(${gradientAngle}deg, ${gradientColor1}, ${gradientColor2})`
 						: `radial-gradient(circle, ${gradientColor1}, ${gradientColor2})`};"
 				></div>
 
-				<div class="gradient-type-selector">
-					<button
-						type="button"
-						class="btn mode-btn"
-						class:active={gradientType === "linear"}
-						onclick={() => {
-							gradientType = "linear";
-							clearPreviews();
-						}}
-					>
-						Linear
-					</button>
-					<button
-						type="button"
-						class="btn mode-btn"
-						class:active={gradientType === "radial"}
-						onclick={() => {
-							gradientType = "radial";
-							clearPreviews();
-						}}
-					>
-						Radial
-					</button>
+				<div class="flex flex-wrap gap-2">
+					<Button variant={gradientType === "linear" ? "default" : "outline"} size="sm" onclick={() => {
+						gradientType = "linear";
+						clearPreviews();
+					}}>Linear</Button>
+					<Button variant={gradientType === "radial" ? "default" : "outline"} size="sm" onclick={() => {
+						gradientType = "radial";
+						clearPreviews();
+					}}>Radial</Button>
 				</div>
 
-				<div class="gradient-controls">
-					<label class="color-input-row">
-						<span>Color 1</span>
-						<input
-							type="color"
-							bind:value={gradientColor1}
-							onchange={clearPreviews}
-						/>
-						<input
-							type="text"
-							bind:value={gradientColor1}
-							onchange={clearPreviews}
-							class="color-hex-input"
-						/>
-					</label>
-					<label class="color-input-row">
-						<span>Color 2</span>
-						<input
-							type="color"
-							bind:value={gradientColor2}
-							onchange={clearPreviews}
-						/>
-						<input
-							type="text"
-							bind:value={gradientColor2}
-							onchange={clearPreviews}
-							class="color-hex-input"
-						/>
-					</label>
-
-					{#if gradientType === "linear"}
-						<div class="style-row">
-							<label for="gradient-angle" class="style-label">Angle</label>
-							<div class="slider-group">
-								<input
-									id="gradient-angle"
-									type="range"
-									min="0"
-									max="360"
-									bind:value={gradientAngle}
-									onchange={clearPreviews}
-								/>
-								<span class="slider-value">{gradientAngle}°</span>
-							</div>
-						</div>
-					{/if}
-
-					<div class="gradient-mode-selector">
-						<span class="mode-label">Span:</span>
-						<div class="mode-buttons">
-							<button
-								type="button"
-								class="btn mode-btn"
-								class:active={gradientMode === "single"}
-								onclick={() => {
-									gradientMode = "single";
-									clearPreviews();
-								}}
-								title="Same gradient on each slide"
-							>
-								Per Slide
-							</button>
-							<button
-								type="button"
-								class="btn mode-btn"
-								class:active={gradientMode === "cover-all"}
-								onclick={() => {
-									gradientMode = "cover-all";
-									clearPreviews();
-								}}
-								title="Gradient spans all slides"
-							>
-								Cover All
-							</button>
-						</div>
+				<div class="flex flex-wrap items-center gap-4">
+					<div class="flex items-center gap-2">
+						<input type="color" bind:value={gradientColor1} onchange={clearPreviews} class="border-input size-9 shrink-0 cursor-pointer rounded-md border bg-transparent p-1" />
+						<Input type="text" bind:value={gradientColor1} onchange={clearPreviews} class="w-28 font-mono" />
+					</div>
+					<div class="flex items-center gap-2">
+						<input type="color" bind:value={gradientColor2} onchange={clearPreviews} class="border-input size-9 shrink-0 cursor-pointer rounded-md border bg-transparent p-1" />
+						<Input type="text" bind:value={gradientColor2} onchange={clearPreviews} class="w-28 font-mono" />
 					</div>
 				</div>
 
-				<div class="gradient-presets">
+				{#if gradientType === "linear"}
+					<div class="grid gap-1.5">
+						<Label for="gradient-angle">Angle ({gradientAngle}°)</Label>
+						<div class="flex h-9 items-center"><Slider type="single" min={0} max={360} bind:value={gradientAngle} onValueChange={clearPreviews} /></div>
+					</div>
+				{/if}
+
+				<div class="grid gap-1.5">
+					<Label>Span</Label>
+					<div class="flex flex-wrap gap-2">
+						<Button variant={gradientMode === "single" ? "default" : "outline"} size="sm" onclick={() => {
+							gradientMode = "single";
+							clearPreviews();
+						}} title="Same gradient on each slide">Per Slide</Button>
+						<Button variant={gradientMode === "cover-all" ? "default" : "outline"} size="sm" onclick={() => {
+							gradientMode = "cover-all";
+							clearPreviews();
+						}} title="Gradient spans all slides">Cover All</Button>
+					</div>
+				</div>
+
+				<div class="flex flex-wrap gap-2">
 					{#each [
 						{ c1: "#667eea", c2: "#764ba2", name: "Purple Dream" },
 						{ c1: "#f093fb", c2: "#f5576c", name: "Pink Sunset" },
@@ -981,1037 +849,225 @@
 						{ c1: "#ff9a9e", c2: "#fecfef", name: "Rose" },
 						{ c1: "#2c3e50", c2: "#4ca1af", name: "Dark Ocean" },
 					] as preset (preset.name)}
-						<button
-							type="button"
-							class="gradient-preset"
-							style="background: linear-gradient(135deg, {preset.c1}, {preset.c2});"
-							onclick={() => {
-								gradientColor1 = preset.c1;
-								gradientColor2 = preset.c2;
-								clearPreviews();
-							}}
-							title={preset.name}
-						></button>
+						<button type="button" class="border-border size-9 rounded-md border" style="background: linear-gradient(135deg, {preset.c1}, {preset.c2});" onclick={() => {
+							gradientColor1 = preset.c1;
+							gradientColor2 = preset.c2;
+							clearPreviews();
+						}} title={preset.name} aria-label={preset.name}></button>
 					{/each}
 				</div>
-			</div>
-		{/if}
-	</section>
+			{/if}
+		</Card.Content>
+	</Card.Root>
 
-	<!-- Batch Images -->
-	<section class="card-section">
-		<div class="section-header">
-			<h2>Carousel Images</h2>
+	<Card.Root class="mb-6">
+		<Card.Header class="flex-row items-center justify-between space-y-0">
+			<Card.Title>Carousel Images</Card.Title>
 			{#if imageFiles.length > 0}
-				<button type="button" class="btn btn-small" onclick={clearAllImages}>Clear All</button>
+				<Button variant="outline" size="sm" onclick={clearAllImages}>Clear All</Button>
 			{/if}
-		</div>
-		<div
-			class="drop-zone images-drop"
-			ondrop={handleImagesDrop}
-			ondragover={handleDragOver}
-			role="button"
-			tabindex="0"
-		>
-			<div class="drop-content">
-				<span class="upload-icon">📷</span>
-				<p>Drag & drop images here</p>
-				<p class="text-muted">or</p>
-				<label class="btn btn-primary">
-					Browse Files
-					<input type="file" accept="image/*" multiple onchange={handleImagesSelect} hidden />
-				</label>
-			</div>
-		</div>
-
-		{#if imagePreviews.length > 0}
-			<p class="text-muted reorder-hint">💡 Drag images to reorder</p>
-			<div class="image-grid">
-				{#each imagePreviews as preview, index (preview)}
-					<div
-						class="image-item"
-						class:dragging={dragIndex === index}
-						class:drag-over={dragOverIndex === index}
-						class:upscaled={upscaledImages.some(u => u.index === index)}
-						draggable="true"
-						ondragstart={() => handleReorderDragStart(index)}
-						ondragover={e => handleReorderDragOver(e, index)}
-						ondrop={() => handleReorderDrop(index)}
-						ondragend={handleReorderDragEnd}
-						role="listitem"
-					>
-						<img src={preview} alt="Preview {index + 1}" />
-						<span class="image-number">{index + 1}</span>
-						{#if upscaledImages.some(u => u.index === index)}
-							{@const info = upscaledImages.find(u => u.index === index)}
-							<span class="upscale-badge" title="Image will be upscaled ({info?.originalWidth}×{info?.originalHeight})">⚠️</span>
-						{/if}
-						<button type="button" class="remove-btn" onclick={() => removeImage(index)}>✕</button>
-					</div>
-				{/each}
-			</div>
-
-			{#if upscaledImages.length > 0}
-				<div class="upscale-warning">
-					<span class="warning-icon">⚠️</span>
-					<span>
-						{upscaledImages.length === 1 ? "1 image" : `${upscaledImages.length} images`} will be upscaled beyond
-						{upscaledImages.length === 1 ? "its" : "their"} original resolution, which may appear blurry.
-					</span>
-				</div>
-			{/if}
-		{/if}
-	</section>
-
-	<!-- Layout Mode -->
-	<section class="card-section">
-		<h2>Layout Mode</h2>
-		<div class="layout-mode-selector">
-			<button
-				type="button"
-				class="btn layout-btn"
-				class:active={layoutMode === "centered"}
-				onclick={() => {
-					layoutMode = "centered";
-					clearPreviews();
-				}}
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			<label
+				class="border-input hover:border-ring hover:bg-accent bg-muted/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
+				ondrop={handleImagesDrop}
+				ondragover={handleDragOver}
 			>
-				<span class="layout-icon">⊕</span>
-				<span class="layout-name">Centered</span>
-				<span class="layout-desc">Image centered on each slide</span>
-			</button>
-			<button
-				type="button"
-				class="btn layout-btn"
-				class:active={layoutMode === "scattered"}
-				onclick={() => {
-					layoutMode = "scattered";
-					clearPreviews();
-				}}
-			>
-				<span class="layout-icon">✦</span>
-				<span class="layout-name">Scattered</span>
-				<span class="layout-desc">Random positions</span>
-			</button>
-		</div>
+				<Upload class="text-muted-foreground size-9" />
+				<p class="font-medium">Drag & drop images here</p>
+				<p class="text-muted-foreground text-sm">or click to browse</p>
+				<input type="file" accept="image/*" multiple onchange={handleImagesSelect} hidden />
+			</label>
 
-		{#if layoutMode === "scattered"}
-			<div class="scatter-options">
-				<div class="style-row">
-					<label for="scatter-spread" class="style-label">Spread</label>
-					<div class="slider-group">
-						<input
-							id="scatter-spread"
-							type="range"
-							min="0"
-							max="100"
-							bind:value={scatterSpread}
-							onchange={clearPreviews}
-						/>
-						<span class="slider-value">{scatterSpread}%</span>
-					</div>
-				</div>
-				<div class="style-row">
-					<label for="scatter-seed" class="style-label">Variation</label>
-					<div class="slider-group">
-						<input
-							id="scatter-seed"
-							type="range"
-							min="1"
-							max="100"
-							bind:value={scatterSeed}
-							onchange={clearPreviews}
-						/>
-						<button
-							type="button"
-							class="btn btn-small"
-							onclick={() => {
-								scatterSeed = Math.floor(Math.random() * 100) + 1;
-								clearPreviews();
-							}}
+			{#if imagePreviews.length > 0}
+				<p class="text-muted-foreground text-sm">💡 Drag images to reorder</p>
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(110px,1fr))] gap-3">
+					{#each imagePreviews as preview, index (preview)}
+						<div
+							class={cn(
+								"group relative overflow-hidden rounded-md border",
+								dragIndex === index && "opacity-50",
+								dragOverIndex === index && "ring-primary ring-2",
+								upscaledImages.some(u => u.index === index) && "border-amber-500/60",
+							)}
+							draggable="true"
+							ondragstart={() => handleReorderDragStart(index)}
+							ondragover={e => handleReorderDragOver(e, index)}
+							ondrop={() => handleReorderDrop(index)}
+							ondragend={handleReorderDragEnd}
+							role="listitem"
 						>
-							🎲 Randomize
-						</button>
-					</div>
-				</div>
-			</div>
-		{/if}
-	</section>
-
-	<!-- Image Styling -->
-	<section class="card-section">
-		<h2>Image Style</h2>
-		<div class="style-controls">
-			<div class="style-row">
-				<label class="style-label">
-					<input
-						type="checkbox"
-						bind:checked={roundedCorners}
-						onchange={clearPreviews}
-					/>
-					Rounded Corners
-				</label>
-			</div>
-
-			{#if roundedCorners}
-				<div class="radius-options">
-					{#each cornerRadiusPresets as preset (preset)}
-						<button
-							type="button"
-							class="btn radius-btn"
-							class:active={cornerRadius === preset}
-							onclick={() => {
-								cornerRadius = preset;
-								clearPreviews();
-							}}>
-							{preset}px
-						</button>
+							<img src={preview} alt="Preview {index + 1}" class="aspect-square w-full cursor-grab object-cover" />
+							<span class="bg-background/80 absolute bottom-1 left-1 rounded px-1.5 py-0.5 text-xs font-medium">{index + 1}</span>
+							{#if upscaledImages.some(u => u.index === index)}
+								{@const info = upscaledImages.find(u => u.index === index)}
+								<span class="absolute bottom-1 right-1 text-xs" title="Image will be upscaled ({info?.originalWidth}×{info?.originalHeight})">⚠️</span>
+							{/if}
+							<button type="button" class="bg-background/80 hover:bg-destructive hover:text-destructive-foreground absolute top-1 right-1 flex size-6 items-center justify-center rounded-full text-xs opacity-0 transition group-hover:opacity-100" onclick={() => removeImage(index)} aria-label="Remove image">✕</button>
+						</div>
 					{/each}
 				</div>
-			{/if}
 
-			<div class="style-row">
-				<label class="style-label">
-					<input
-						type="checkbox"
-						bind:checked={dropShadow}
-						onchange={clearPreviews}
-					/>
-					Drop Shadow
-				</label>
-			</div>
-
-			{#if dropShadow}
-				<div class="shadow-options">
-					<div class="style-row">
-						<label for="shadow-blur" class="style-label">Blur</label>
-						<div class="slider-group">
-							<input
-								id="shadow-blur"
-								type="range"
-								min="5"
-								max="80"
-								bind:value={shadowBlur}
-								onchange={clearPreviews}
-							/>
-							<span class="slider-value">{shadowBlur}px</span>
-						</div>
-					</div>
-					<div class="style-row">
-						<label for="shadow-offset" class="style-label">Offset</label>
-						<div class="slider-group">
-							<input
-								id="shadow-offset"
-								type="range"
-								min="0"
-								max="50"
-								bind:value={shadowOffsetY}
-								onchange={clearPreviews}
-							/>
-							<span class="slider-value">{shadowOffsetY}px</span>
-						</div>
-					</div>
-				</div>
-			{/if}
-		</div>
-	</section>
-
-	<!-- Generate Preview Button -->
-	<section class="text-center mb-3">
-		<button
-			type="button"
-			class="btn btn-primary btn-large"
-			onclick={generatePreviews}
-			disabled={!canGeneratePreviews || processing}
-		>
-			{#if processing && !previewsGenerated}
-				<span class="spinner"></span>
-				Generating {processedCount}/{imageFiles.length}...
-			{:else}
-				👁️ Generate Preview
-			{/if}
-		</button>
-		{#if !canProcess && !processing}
-			<p class="text-muted hint">Add a background and at least one image to continue</p>
-		{/if}
-	</section>
-
-	<!-- Preview Section -->
-	{#if previewsGenerated && processedPreviews.length > 0}
-		<section class="card-section">
-			<div class="section-header">
-				<h2>Preview ({processedPreviews.length} images)</h2>
-				<span class="preview-resolution">{width} × {height}px</span>
-			</div>
-			<div class="preview-grid">
-				{#each processedPreviews as preview, index (preview)}
-					<div class="preview-item">
-						<div class="preview-image-wrapper" style="aspect-ratio: {width} / {height};">
-							<img src={preview} alt="Final image {index + 1}" loading="lazy" />
-						</div>
-						<span class="image-number">{index + 1}</span>
-					</div>
-				{/each}
-			</div>
-
-			<div class="export-options">
-				<div class="format-selector">
-					<span class="mode-label">Format:</span>
-					<div class="mode-buttons">
-						<button
-							type="button"
-							class="btn mode-btn"
-							class:active={exportFormat === "png"}
-							onclick={() => {
-								exportFormat = "png";
-							}}
-						>
-							PNG
-						</button>
-						<button
-							type="button"
-							class="btn mode-btn"
-							class:active={exportFormat === "jpg"}
-							onclick={() => {
-								exportFormat = "jpg";
-							}}
-						>
-							JPG
-						</button>
-					</div>
-				</div>
-
-				{#if exportFormat === "jpg"}
-					<div class="quality-slider">
-						<label for="jpg-quality" class="style-label">Quality</label>
-						<div class="slider-group">
-							<input
-								id="jpg-quality"
-								type="range"
-								min="50"
-								max="100"
-								bind:value={jpgQuality}
-							/>
-							<span class="slider-value">{jpgQuality}%</span>
-						</div>
+				{#if upscaledImages.length > 0}
+					<div class="flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
+						<span>⚠️</span>
+						<span>
+							{upscaledImages.length === 1 ? "1 image" : `${upscaledImages.length} images`} will be upscaled beyond
+							{upscaledImages.length === 1 ? "its" : "their"} original resolution, which may appear blurry.
+						</span>
 					</div>
 				{/if}
-			</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
 
-			<div class="text-center mt-2">
+	<Card.Root class="mb-6">
+		<Card.Header><Card.Title>Layout Mode</Card.Title></Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="grid gap-3 sm:grid-cols-2">
 				<button
 					type="button"
-					class="btn btn-primary btn-large"
-					onclick={downloadZip}
-					disabled={processing}
+					class={cn("flex flex-col items-start gap-1 rounded-lg border p-4 text-left transition-colors", layoutMode === "centered" ? "border-primary bg-accent" : "border-border hover:bg-accent/50")}
+					onclick={() => {
+						layoutMode = "centered";
+						clearPreviews();
+					}}
 				>
-					{#if processing}
-						<span class="spinner"></span>
-						Creating ZIP...
-					{:else}
-						🚀 Download ZIP
-					{/if}
+					<span class="font-semibold">Centered</span>
+					<span class="text-muted-foreground text-sm">Image centered on each slide</span>
+				</button>
+				<button
+					type="button"
+					class={cn("flex flex-col items-start gap-1 rounded-lg border p-4 text-left transition-colors", layoutMode === "scattered" ? "border-primary bg-accent" : "border-border hover:bg-accent/50")}
+					onclick={() => {
+						layoutMode = "scattered";
+						clearPreviews();
+					}}
+				>
+					<span class="font-semibold">Scattered</span>
+					<span class="text-muted-foreground text-sm">Random positions</span>
 				</button>
 			</div>
-		</section>
+
+			{#if layoutMode === "scattered"}
+				<div class="grid gap-1.5">
+					<Label for="scatter-spread">Spread ({scatterSpread}%)</Label>
+					<div class="flex h-9 items-center"><Slider type="single" min={0} max={100} bind:value={scatterSpread} onValueChange={clearPreviews} /></div>
+				</div>
+				<div class="grid gap-1.5">
+					<Label for="scatter-seed">Variation</Label>
+					<div class="flex items-center gap-3">
+						<Slider type="single" min={1} max={100} bind:value={scatterSeed} onValueChange={clearPreviews} />
+						<Button variant="outline" size="sm" class="shrink-0" onclick={() => {
+							scatterSeed = Math.floor(Math.random() * 100) + 1;
+							clearPreviews();
+						}}><Shuffle class="size-4" /> Randomize</Button>
+					</div>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="mb-6">
+		<Card.Header><Card.Title>Image Style</Card.Title></Card.Header>
+		<Card.Content class="space-y-4">
+			<Label class="font-normal"><Checkbox bind:checked={roundedCorners} onCheckedChange={clearPreviews} /> Rounded Corners</Label>
+
+			{#if roundedCorners}
+				<div class="flex flex-wrap gap-2">
+					{#each cornerRadiusPresets as preset (preset)}
+						<Button variant={cornerRadius === preset ? "default" : "outline"} size="sm" onclick={() => {
+							cornerRadius = preset;
+							clearPreviews();
+						}}>{preset}px</Button>
+					{/each}
+				</div>
+			{/if}
+
+			<Label class="font-normal"><Checkbox bind:checked={dropShadow} onCheckedChange={clearPreviews} /> Drop Shadow</Label>
+
+			{#if dropShadow}
+				<div class="grid gap-1.5">
+					<Label for="shadow-blur">Blur ({shadowBlur}px)</Label>
+					<div class="flex h-9 items-center"><Slider type="single" min={5} max={80} bind:value={shadowBlur} onValueChange={clearPreviews} /></div>
+				</div>
+				<div class="grid gap-1.5">
+					<Label for="shadow-offset">Offset ({shadowOffsetY}px)</Label>
+					<div class="flex h-9 items-center"><Slider type="single" min={0} max={50} bind:value={shadowOffsetY} onValueChange={clearPreviews} /></div>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<div class="mb-6 text-center">
+		<Button size="lg" onclick={generatePreviews} disabled={!canGeneratePreviews || processing}>
+			{#if processing && !previewsGenerated}
+				<LoaderCircle class="size-4 animate-spin" />
+				Generating {processedCount}/{imageFiles.length}...
+			{:else}
+				<Eye class="size-4" />
+				Generate Preview
+			{/if}
+		</Button>
+		{#if !canProcess && !processing}
+			<p class="text-muted-foreground mt-2 text-sm">Add a background and at least one image to continue</p>
+		{/if}
+	</div>
+
+	{#if previewsGenerated && processedPreviews.length > 0}
+		<Card.Root class="mb-6">
+			<Card.Header class="flex-row items-center justify-between space-y-0">
+				<Card.Title>Preview ({processedPreviews.length} images)</Card.Title>
+				<span class="text-muted-foreground text-sm">{width} × {height}px</span>
+			</Card.Header>
+			<Card.Content class="space-y-4">
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+					{#each processedPreviews as preview, index (preview)}
+						<div class="relative overflow-hidden rounded-md border">
+							<div class="w-full" style="aspect-ratio: {width} / {height};">
+								<img src={preview} alt="Final image {index + 1}" loading="lazy" class="size-full object-cover" />
+							</div>
+							<span class="bg-background/80 absolute bottom-1 left-1 rounded px-1.5 py-0.5 text-xs font-medium">{index + 1}</span>
+						</div>
+					{/each}
+				</div>
+
+				<div class="flex flex-wrap items-center gap-4">
+					<div class="grid gap-1.5">
+						<Label>Format</Label>
+						<div class="flex gap-2">
+							<Button variant={exportFormat === "png" ? "default" : "outline"} size="sm" onclick={() => {
+								exportFormat = "png";
+							}}>PNG</Button>
+							<Button variant={exportFormat === "jpg" ? "default" : "outline"} size="sm" onclick={() => {
+								exportFormat = "jpg";
+							}}>JPG</Button>
+						</div>
+					</div>
+					{#if exportFormat === "jpg"}
+						<div class="grid min-w-[200px] flex-1 gap-1.5">
+							<Label for="jpg-quality">Quality ({jpgQuality}%)</Label>
+							<div class="flex h-9 items-center"><Slider type="single" min={50} max={100} bind:value={jpgQuality} /></div>
+						</div>
+					{/if}
+				</div>
+
+				<div class="text-center">
+					<Button size="lg" onclick={downloadZip} disabled={processing}>
+						{#if processing}
+							<LoaderCircle class="size-4 animate-spin" />
+							Creating ZIP...
+						{:else}
+							<Package class="size-4" />
+							Download ZIP
+						{/if}
+					</Button>
+				</div>
+			</Card.Content>
+		</Card.Root>
 	{/if}
 
-	<footer class="text-center text-muted">
+	<footer class="text-muted-foreground text-center text-sm">
 		<p>✨ Images processed in your browser • No upload required</p>
 	</footer>
 </main>
-
-<style>
-	/* Resolution controls */
-	.resolution-controls {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	.presets {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-	}
-
-	.preset-btn {
-		background: white;
-		border: 1px solid #e2e8f0;
-		color: #4a5568;
-	}
-
-	.preset-btn:hover {
-		border-color: #007acc;
-		color: #007acc;
-	}
-
-	.preset-btn.active {
-		background: #007acc;
-		border-color: #007acc;
-		color: white;
-	}
-
-	.custom-size {
-		display: flex;
-		align-items: flex-end;
-		gap: 0.5rem;
-	}
-
-	.size-input {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		width: 120px;
-	}
-
-	.size-separator {
-		padding-bottom: 0.6rem;
-		color: #718096;
-		font-size: 1.25rem;
-	}
-
-	/* Background preview */
-	.background-preview {
-		position: relative;
-		display: inline-block;
-	}
-
-	.background-preview img {
-		max-width: 100%;
-		max-height: 200px;
-		border-radius: 8px;
-	}
-
-	.preview-overlay {
-		position: absolute;
-		top: 0.5rem;
-		right: 0.5rem;
-	}
-
-	/* Background type selector */
-	.bg-type-selector {
-		display: flex;
-		gap: 0.5rem;
-		margin-bottom: 1rem;
-	}
-
-	.bg-type-btn {
-		flex: 1;
-		padding: 0.75rem 1rem;
-		background: white;
-		border: 1px solid #e2e8f0;
-		color: #4a5568;
-		font-size: 0.9rem;
-	}
-
-	.bg-type-btn:hover {
-		border-color: #007acc;
-		color: #007acc;
-	}
-
-	.bg-type-btn.active {
-		background: #007acc;
-		border-color: #007acc;
-		color: white;
-	}
-
-	/* Color picker section */
-	.color-picker-section,
-	.gradient-picker-section {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	.color-preview-large {
-		width: 100%;
-		height: 120px;
-		border-radius: 8px;
-		border: 1px solid #e2e8f0;
-	}
-
-	.color-controls,
-	.gradient-controls {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.color-input-row {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-	}
-
-	.color-input-row span {
-		min-width: 60px;
-		font-weight: 500;
-		color: #4a5568;
-	}
-
-	.color-input-row input[type="color"] {
-		width: 40px;
-		height: 40px;
-		border: none;
-		border-radius: 8px;
-		cursor: pointer;
-		padding: 0;
-		background: none;
-	}
-
-	.color-input-row input[type="color"]::-webkit-color-swatch-wrapper {
-		padding: 0;
-	}
-
-	.color-input-row input[type="color"]::-webkit-color-swatch {
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-	}
-
-	.color-hex-input {
-		width: 90px;
-		padding: 0.5rem;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		font-family: monospace;
-		font-size: 0.9rem;
-	}
-
-	.color-presets,
-	.gradient-presets {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-	}
-
-	.color-preset,
-	.gradient-preset {
-		width: 36px;
-		height: 36px;
-		border-radius: 8px;
-		border: 2px solid transparent;
-		cursor: pointer;
-		transition: transform 0.15s, border-color 0.15s;
-	}
-
-	.color-preset:hover,
-	.gradient-preset:hover {
-		transform: scale(1.1);
-		border-color: #007acc;
-	}
-
-	.gradient-type-selector {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	.gradient-type-selector .mode-btn {
-		flex: 1;
-	}
-
-	.gradient-mode-selector {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		margin-top: 0.5rem;
-		padding-top: 0.75rem;
-		border-top: 1px solid #e2e8f0;
-	}
-
-	/* Drop content */
-	.drop-content {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.upload-icon {
-		font-size: 3rem;
-	}
-
-	/* Section header */
-	.section-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1rem;
-	}
-
-	.section-header h2 {
-		margin-bottom: 0;
-	}
-
-	.btn-small {
-		padding: 0.4rem 0.75rem;
-		font-size: 0.85rem;
-		background: #e2e8f0;
-		color: #4a5568;
-	}
-
-	.btn-small:hover {
-		background: #cbd5e0;
-	}
-
-	/* Images drop zone */
-	.images-drop {
-		margin-bottom: 1rem;
-	}
-
-	.reorder-hint {
-		margin-bottom: 0.5rem;
-		font-size: 0.85rem;
-	}
-
-	/* Image grid */
-	.image-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
-		gap: 0.75rem;
-	}
-
-	.image-item {
-		position: relative;
-		aspect-ratio: 1;
-		border-radius: 8px;
-		overflow: hidden;
-		background: #f7fafc;
-		cursor: grab;
-		transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s;
-		border: 2px solid transparent;
-	}
-
-	.image-item:active {
-		cursor: grabbing;
-	}
-
-	.image-item.dragging {
-		opacity: 0.5;
-		transform: scale(0.95);
-	}
-
-	.image-item.drag-over {
-		border-color: #007acc;
-		transform: scale(1.02);
-		box-shadow: 0 4px 12px rgba(0, 122, 204, 0.3);
-	}
-
-	.image-item.upscaled {
-		border-color: #ed8936;
-	}
-
-	.image-item img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-	}
-
-	.image-number {
-		position: absolute;
-		bottom: 0.25rem;
-		left: 0.25rem;
-		background: rgba(0, 0, 0, 0.6);
-		color: white;
-		font-size: 0.75rem;
-		padding: 0.15rem 0.4rem;
-		border-radius: 4px;
-	}
-
-	.upscale-badge {
-		position: absolute;
-		top: 0.25rem;
-		left: 0.25rem;
-		font-size: 0.9rem;
-		filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
-	}
-
-	.upscale-warning {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-top: 1rem;
-		padding: 0.75rem 1rem;
-		background: #fffaf0;
-		border: 1px solid #ed8936;
-		border-radius: 8px;
-		color: #c05621;
-		font-size: 0.9rem;
-	}
-
-	.warning-icon {
-		font-size: 1.1rem;
-	}
-
-	/* Remove button */
-	.remove-btn {
-		position: absolute;
-		top: 0.25rem;
-		right: 0.25rem;
-		background: #e53e3e;
-		color: white;
-		border: none;
-		width: 24px;
-		height: 24px;
-		border-radius: 50%;
-		cursor: pointer;
-		font-size: 0.85rem;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		opacity: 0;
-		transition: opacity 0.2s;
-	}
-
-	.image-item:hover .remove-btn,
-	.background-preview:hover .remove-btn,
-	.preview-overlay .remove-btn {
-		opacity: 1;
-	}
-
-	.remove-btn:hover {
-		background: #c53030;
-	}
-
-	/* Large button */
-	.btn-large {
-		padding: 1rem 2rem;
-		font-size: 1.1rem;
-	}
-
-	.hint {
-		margin-top: 0.75rem;
-		font-size: 0.9rem;
-	}
-
-	/* Background mode selector */
-	.bg-mode-selector {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		margin-top: 1rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-	}
-
-	.mode-label {
-		font-weight: 500;
-		color: #4a5568;
-		white-space: nowrap;
-	}
-
-	.mode-buttons {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	.mode-btn {
-		background: white;
-		border: 1px solid #e2e8f0;
-		color: #4a5568;
-		padding: 0.4rem 0.75rem;
-		font-size: 0.9rem;
-	}
-
-	.mode-btn:hover {
-		border-color: #007acc;
-		color: #007acc;
-	}
-
-	.mode-btn.active {
-		background: #007acc;
-		border-color: #007acc;
-		color: white;
-	}
-
-	/* Preview grid */
-	.preview-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-		gap: 1rem;
-	}
-
-	.preview-item {
-		position: relative;
-		border-radius: 8px;
-		overflow: hidden;
-		background: #f7fafc;
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-	}
-
-	.preview-image-wrapper {
-		position: relative;
-		width: 100%;
-		background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-		background-size: 200% 100%;
-		animation: loading 1.5s ease-in-out infinite;
-	}
-
-	@keyframes loading {
-		0% {
-			background-position: 200% 0;
-		}
-		100% {
-			background-position: -200% 0;
-		}
-	}
-
-	.preview-image-wrapper img {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		object-fit: contain;
-	}
-
-	.preview-item .image-number {
-		bottom: 0.5rem;
-		left: 0.5rem;
-		font-size: 0.85rem;
-		padding: 0.25rem 0.5rem;
-	}
-
-	.preview-resolution {
-		font-size: 0.9rem;
-		color: #718096;
-	}
-
-	.mt-2 {
-		margin-top: 1.5rem;
-	}
-
-	/* Style controls */
-	.style-controls {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-	}
-
-	.style-row {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-	}
-
-	.style-label {
-		min-width: 140px;
-		font-weight: 500;
-		color: #4a5568;
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.style-label input[type="checkbox"] {
-		width: 18px;
-		height: 18px;
-		accent-color: #007acc;
-	}
-
-	.slider-group {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		flex: 1;
-	}
-
-	.slider-group input[type="range"] {
-		flex: 1;
-		height: 6px;
-		border-radius: 3px;
-		background: #e2e8f0;
-		appearance: none;
-		cursor: pointer;
-	}
-
-	.slider-group input[type="range"]::-webkit-slider-thumb {
-		appearance: none;
-		width: 18px;
-		height: 18px;
-		border-radius: 50%;
-		background: #007acc;
-		cursor: pointer;
-	}
-
-	.slider-group input[type="range"]::-moz-range-thumb {
-		width: 18px;
-		height: 18px;
-		border-radius: 50%;
-		background: #007acc;
-		cursor: pointer;
-		border: none;
-	}
-
-	.slider-value {
-		min-width: 50px;
-		text-align: right;
-		font-size: 0.9rem;
-		color: #718096;
-		font-variant-numeric: tabular-nums;
-	}
-
-	.shadow-options {
-		margin-left: 1.5rem;
-		padding-left: 1rem;
-		border-left: 2px solid #e2e8f0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.radius-options {
-		display: flex;
-		gap: 0.5rem;
-		margin-left: 1.5rem;
-		padding-left: 1rem;
-		border-left: 2px solid #e2e8f0;
-	}
-
-	.radius-btn {
-		background: white;
-		border: 1px solid #e2e8f0;
-		color: #4a5568;
-		padding: 0.4rem 0.75rem;
-		font-size: 0.9rem;
-	}
-
-	.radius-btn:hover {
-		border-color: #007acc;
-		color: #007acc;
-	}
-
-	.radius-btn.active {
-		background: #007acc;
-		border-color: #007acc;
-		color: white;
-	}
-
-	/* Layout mode selector */
-	.layout-mode-selector {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		gap: 1rem;
-	}
-
-	.layout-btn {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.25rem;
-		padding: 1rem;
-		background: white;
-		border: 2px solid #e2e8f0;
-		border-radius: 12px;
-		cursor: pointer;
-		transition: all 0.2s;
-	}
-
-	.layout-btn:hover {
-		border-color: #007acc;
-	}
-
-	.layout-btn.active {
-		border-color: #007acc;
-		background: #f0f7ff;
-	}
-
-	.layout-icon {
-		font-size: 1.75rem;
-	}
-
-	.layout-name {
-		font-weight: 600;
-		color: #2d3748;
-	}
-
-	.layout-desc {
-		font-size: 0.8rem;
-		color: #718096;
-	}
-
-	.scatter-options {
-		margin-top: 1rem;
-		padding-top: 1rem;
-		border-top: 1px solid #e2e8f0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	/* Export options */
-	.export-options {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-		margin-top: 1.5rem;
-		padding-top: 1.5rem;
-		border-top: 1px solid #e2e8f0;
-	}
-
-	.format-selector {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		justify-content: center;
-	}
-
-	.quality-slider {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		max-width: 400px;
-		margin: 0 auto;
-	}
-
-	.quality-slider .style-label {
-		min-width: auto;
-	}
-
-	/* Responsive */
-	@media (max-width: 600px) {
-		.custom-size {
-			flex-wrap: wrap;
-		}
-
-		.size-input {
-			width: 100px;
-		}
-
-		.image-grid {
-			grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-		}
-
-		.preview-grid {
-			grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-		}
-
-		.bg-mode-selector {
-			flex-direction: column;
-			align-items: flex-start;
-			gap: 0.5rem;
-		}
-
-		.style-row {
-			flex-direction: column;
-			align-items: flex-start;
-			gap: 0.5rem;
-		}
-
-		.style-label {
-			min-width: auto;
-		}
-
-		.slider-group {
-			width: 100%;
-		}
-
-		.shadow-options {
-			margin-left: 0;
-			padding-left: 0;
-			border-left: none;
-			padding-top: 0.5rem;
-			border-top: 1px solid #e2e8f0;
-		}
-	}
-</style>

--- a/src/routes/tools/panorama-splitter/+page.svelte
+++ b/src/routes/tools/panorama-splitter/+page.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
 	import { resolve as resolvePath } from "$app/paths";
+	import { Button } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Label } from "$lib/components/ui/label";
+	import { Slider } from "$lib/components/ui/slider";
+	import { Columns3, Eye, LoaderCircle, Package, Upload, X } from "@lucide/svelte";
 	import JSZip from "jszip";
 
 	// Image state
@@ -302,81 +307,73 @@
 	<title>Panorama Splitter for Instagram</title>
 </svelte:head>
 
-<main class="page-container">
-	<a href={resolvePath("/")} class="back-link">← Back to Tools</a>
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
 
-	<h1>🌄 Panorama Splitter</h1>
-	<p class="subtitle">Split wide panorama images into Instagram carousel slides</p>
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight">
+		<Columns3 class="text-primary size-7" />
+		Panorama Splitter
+	</h1>
+	<p class="text-muted-foreground mb-8">Split wide panorama images into Instagram carousel slides</p>
 
-	<!-- Image Upload -->
-	<section class="card-section">
-		<h2>Panorama Image</h2>
-		<div
-			class="drop-zone"
-			class:has-file={imageFile}
-			ondrop={handleImageDrop}
-			ondragover={handleDragOver}
-			role="button"
-			tabindex="0"
-		>
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Panorama Image</Card.Title>
+		</Card.Header>
+		<Card.Content>
 			{#if imagePreview}
-				<div class="image-preview">
-					<img src={imagePreview} alt="Panorama preview" />
-					<div class="preview-overlay">
-						<button type="button" class="remove-btn" onclick={clearImage}>✕</button>
-					</div>
+				<div class="relative overflow-hidden rounded-lg border">
+					<img src={imagePreview} alt="Panorama preview" class="max-h-64 w-full object-contain" />
+					<Button variant="destructive" size="icon" class="absolute top-2 right-2 size-8" onclick={clearImage}><X class="size-4" /></Button>
 				</div>
 				{#if imageDimensions}
-					<p class="dimensions-info">{imageDimensions.width} × {imageDimensions.height}px</p>
+					<p class="text-muted-foreground mt-2 text-center text-sm">{imageDimensions.width} × {imageDimensions.height}px</p>
 				{/if}
 			{:else}
-				<div class="drop-content">
-					<span class="upload-icon">🌄</span>
-					<p>Drag & drop a panorama image</p>
-					<p class="text-muted">or</p>
-					<label class="btn btn-primary">
-						Browse Files
-						<input type="file" accept="image/*" onchange={handleImageSelect} hidden />
-					</label>
-				</div>
+				<label
+					class="border-input hover:border-ring hover:bg-accent bg-muted/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
+					ondrop={handleImageDrop}
+					ondragover={handleDragOver}
+				>
+					<Upload class="text-muted-foreground size-9" />
+					<p class="font-medium">Drag & drop a panorama image</p>
+					<p class="text-muted-foreground text-sm">or click to browse</p>
+					<input type="file" accept="image/*" onchange={handleImageSelect} hidden />
+				</label>
 			{/if}
-		</div>
-	</section>
+		</Card.Content>
+	</Card.Root>
 
-	<!-- Split Settings -->
-	<section class="card-section">
-		<h2>Split Settings</h2>
-
-		<div class="settings-grid">
-			<!-- Number of splits -->
-			<div class="setting-group">
-				<p class="setting-label">Number of Slides</p>
-				<div class="split-count-buttons">
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Split Settings</Card.Title>
+		</Card.Header>
+		<Card.Content class="space-y-5">
+			<div class="grid gap-1.5">
+				<Label>Number of Slides</Label>
+				<div class="flex flex-wrap gap-2">
 					{#each splitCountOptions as count (count)}
-						<button
-							type="button"
-							class="btn count-btn"
-							class:active={splitCount === count}
+						<Button
+							variant={splitCount === count ? "default" : "outline"}
+							size="icon"
 							onclick={() => {
 								splitCount = count;
 								clearPreviews();
 							}}
 						>
 							{count}
-						</button>
+						</Button>
 					{/each}
 				</div>
 			</div>
 
-			<!-- Aspect ratio -->
-			<div class="setting-group">
-				<p class="setting-label">Output Aspect Ratio</p>
-				<div class="option-buttons">
+			<div class="grid gap-1.5">
+				<Label>Output Aspect Ratio</Label>
+				<div class="flex flex-wrap gap-2">
 					{#each aspectRatioOptions as option (option.value)}
-						<button
-							type="button"
-							class="btn option-btn"
-							class:active={outputAspectRatio === option.value}
+						<Button
+							variant={outputAspectRatio === option.value ? "default" : "outline"}
+							size="sm"
 							onclick={() => {
 								outputAspectRatio = option.value;
 								clearPreviews();
@@ -384,47 +381,33 @@
 							title={option.desc}
 						>
 							{option.label}
-						</button>
+						</Button>
 					{/each}
 				</div>
 			</div>
 
-			<!-- Padding -->
-			<div class="setting-group">
-				<label class="setting-label" for="padding">Padding</label>
-				<div class="padding-controls">
-					<div class="slider-group">
-						<input
-							id="padding"
-							type="range"
-							min="0"
-							max="20"
-							bind:value={paddingPercent}
-							onchange={clearPreviews}
-						/>
-						<span class="slider-value">{paddingPercent}%</span>
+			<div class="grid gap-1.5">
+				<Label for="padding">Padding</Label>
+				<div class="flex flex-wrap items-center gap-4">
+					<div class="flex flex-1 items-center gap-3">
+						<Slider type="single" min={0} max={20} bind:value={paddingPercent} onValueChange={clearPreviews} />
+						<span class="text-muted-foreground w-10 shrink-0 text-sm">{paddingPercent}%</span>
 					</div>
 					{#if paddingPercent > 0}
-						<div class="color-picker">
-							<label for="padding-color">Color</label>
-							<input
-								id="padding-color"
-								type="color"
-								bind:value={paddingColor}
-								onchange={clearPreviews}
-							/>
+						<div class="flex items-center gap-2">
+							<Label for="padding-color">Color</Label>
+							<input id="padding-color" type="color" bind:value={paddingColor} onchange={clearPreviews} class="border-input size-9 cursor-pointer rounded-md border bg-transparent p-1" />
 						</div>
 					{/if}
 				</div>
 				{#if paddingPercent > 0}
-					<div class="padding-mode-section">
-						<p class="setting-label">Apply To</p>
-						<div class="option-buttons">
+					<div class="mt-2 grid gap-1.5">
+						<Label>Apply To</Label>
+						<div class="flex flex-wrap gap-2">
 							{#each paddingModeOptions as mode (mode.value)}
-								<button
-									type="button"
-									class="btn option-btn"
-									class:active={paddingMode === mode.value}
+								<Button
+									variant={paddingMode === mode.value ? "default" : "outline"}
+									size="sm"
 									onclick={() => {
 										paddingMode = mode.value;
 										clearPreviews();
@@ -432,10 +415,10 @@
 									title={mode.desc}
 								>
 									{mode.label}
-								</button>
+								</Button>
 							{/each}
 						</div>
-						<p class="setting-hint">
+						<p class="text-muted-foreground text-sm">
 							{#if paddingMode === "per-slide"}
 								Padding around each individual slide
 							{:else}
@@ -445,461 +428,78 @@
 					</div>
 				{/if}
 			</div>
-		</div>
 
-		<!-- Pixelation warning -->
-		{#if pixelationWarning()}
-			{@const warning = pixelationWarning()}
-			<div class="pixelation-warning">
-				<span class="warning-icon">⚠️</span>
-				<span>
-					Image will be upscaled by {warning?.scale.toFixed(1)}× which may appear blurry.
-					Source segment size: {warning?.sourceWidth}×{warning?.sourceHeight}px
-				</span>
-			</div>
-		{/if}
-	</section>
+			{#if pixelationWarning()}
+				{@const warning = pixelationWarning()}
+				<div class="flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
+					<span>⚠️</span>
+					<span>
+						Image will be upscaled by {warning?.scale.toFixed(1)}× which may appear blurry.
+						Source segment size: {warning?.sourceWidth}×{warning?.sourceHeight}px
+					</span>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
 
-	<!-- Generate Preview Button -->
-	<section class="text-center mb-3">
-		<button
-			type="button"
-			class="btn btn-primary btn-large"
-			onclick={generatePreviews}
-			disabled={!canGeneratePreviews || processing}
-		>
+	<div class="mb-6 text-center">
+		<Button size="lg" onclick={generatePreviews} disabled={!canGeneratePreviews || processing}>
 			{#if processing && !previewsGenerated}
-				<span class="spinner"></span>
+				<LoaderCircle class="size-4 animate-spin" />
 				Generating {processedCount}/{splitCount}...
 			{:else}
-				👁️ Generate Preview
+				<Eye class="size-4" />
+				Generate Preview
 			{/if}
-		</button>
+		</Button>
 		{#if !canProcess && !processing}
-			<p class="text-muted hint">Add a panorama image to continue</p>
+			<p class="text-muted-foreground mt-2 text-sm">Add a panorama image to continue</p>
 		{/if}
-	</section>
+	</div>
 
-	<!-- Preview Section -->
 	{#if previewsGenerated && processedPreviews.length > 0}
-		<section class="card-section">
-			<div class="section-header">
-				<h2>Preview ({processedPreviews.length} slides)</h2>
-				<span class="preview-resolution">{outputWidth} × {outputHeight}px each</span>
-			</div>
+		<Card.Root class="mb-6">
+			<Card.Header class="flex-row items-center justify-between space-y-0">
+				<Card.Title>Preview ({processedPreviews.length} slides)</Card.Title>
+				<span class="text-muted-foreground text-sm">{outputWidth} × {outputHeight}px each</span>
+			</Card.Header>
+			<Card.Content class="space-y-4">
+				<div class="flex snap-x gap-2 overflow-x-auto pb-2">
+					{#each processedPreviews as preview, index (preview)}
+						<div class="relative shrink-0 snap-center">
+							<img src={preview} alt="Slide {index + 1}" class="h-56 rounded-md border object-contain" />
+							<span class="bg-background/80 absolute bottom-2 left-2 rounded px-1.5 py-0.5 text-xs font-medium">{index + 1}</span>
+						</div>
+					{/each}
+				</div>
 
-			<!-- Carousel simulation -->
-			<div class="carousel-preview">
-				{#each processedPreviews as preview, index (preview)}
-					<div class="carousel-slide">
-						<img src={preview} alt="Slide {index + 1}" />
-						<span class="slide-number">{index + 1}</span>
-					</div>
-				{/each}
-			</div>
+				<p class="text-muted-foreground text-center text-sm">← Scroll to preview the carousel →</p>
 
-			<p class="text-muted text-center carousel-hint">← Scroll to preview the carousel →</p>
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3">
+					{#each processedPreviews as preview, index (preview)}
+						<div class="relative overflow-hidden rounded-md border">
+							<img src={preview} alt="Final image {index + 1}" class="w-full object-contain" />
+							<span class="bg-background/80 absolute bottom-1 left-1 rounded px-1.5 py-0.5 text-xs font-medium">{index + 1}</span>
+						</div>
+					{/each}
+				</div>
 
-			<!-- Grid preview -->
-			<div class="preview-grid">
-				{#each processedPreviews as preview, index (preview)}
-					<div class="preview-item">
-						<img src={preview} alt="Final image {index + 1}" />
-						<span class="image-number">{index + 1}</span>
-					</div>
-				{/each}
-			</div>
-
-			<div class="text-center mt-2">
-				<button
-					type="button"
-					class="btn btn-primary btn-large"
-					onclick={downloadZip}
-					disabled={processing}
-				>
-					{#if processing}
-						<span class="spinner"></span>
-						Creating ZIP...
-					{:else}
-						🚀 Download ZIP
-					{/if}
-				</button>
-			</div>
-		</section>
+				<div class="text-center">
+					<Button size="lg" onclick={downloadZip} disabled={processing}>
+						{#if processing}
+							<LoaderCircle class="size-4 animate-spin" />
+							Creating ZIP...
+						{:else}
+							<Package class="size-4" />
+							Download ZIP
+						{/if}
+					</Button>
+				</div>
+			</Card.Content>
+		</Card.Root>
 	{/if}
 
-	<footer class="text-center text-muted">
+	<footer class="text-muted-foreground text-center text-sm">
 		<p>✨ Images processed in your browser • No upload required</p>
 	</footer>
 </main>
-
-<style>
-	/* Image preview */
-	.image-preview {
-		position: relative;
-		display: inline-block;
-		max-width: 100%;
-	}
-
-	.image-preview img {
-		max-width: 100%;
-		max-height: 300px;
-		border-radius: 8px;
-		object-fit: contain;
-	}
-
-	.preview-overlay {
-		position: absolute;
-		top: 0.5rem;
-		right: 0.5rem;
-	}
-
-	.dimensions-info {
-		margin-top: 0.5rem;
-		font-size: 0.9rem;
-		color: #718096;
-	}
-
-	/* Drop content */
-	.drop-content {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.upload-icon {
-		font-size: 3rem;
-	}
-
-	/* Remove button */
-	.remove-btn {
-		position: absolute;
-		top: 0.25rem;
-		right: 0.25rem;
-		background: #e53e3e;
-		color: white;
-		border: none;
-		width: 24px;
-		height: 24px;
-		border-radius: 50%;
-		cursor: pointer;
-		font-size: 0.85rem;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		opacity: 0;
-		transition: opacity 0.2s;
-	}
-
-	.image-preview:hover .remove-btn {
-		opacity: 1;
-	}
-
-	.remove-btn:hover {
-		background: #c53030;
-	}
-
-	/* Settings */
-	.settings-grid {
-		display: flex;
-		flex-direction: column;
-		gap: 1.5rem;
-	}
-
-	.setting-group {
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-	}
-
-		.setting-label {
-			font-weight: 500;
-			color: #4a5568;
-			margin: 0;
-		}
-
-	.setting-hint {
-		font-size: 0.85rem;
-		color: #718096;
-		margin: 0;
-	}
-
-	/* Split count buttons */
-	.split-count-buttons {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-	}
-
-	.count-btn {
-		background: white;
-		border: 1px solid #e2e8f0;
-		color: #4a5568;
-		padding: 0.5rem 1rem;
-		min-width: 48px;
-	}
-
-	.count-btn:hover {
-		border-color: #007acc;
-		color: #007acc;
-	}
-
-	.count-btn.active {
-		background: #007acc;
-		border-color: #007acc;
-		color: white;
-	}
-
-	/* Option buttons */
-	.option-buttons {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-	}
-
-	.option-btn {
-		background: white;
-		border: 1px solid #e2e8f0;
-		color: #4a5568;
-		padding: 0.5rem 1rem;
-	}
-
-	.option-btn:hover {
-		border-color: #007acc;
-		color: #007acc;
-	}
-
-	.option-btn.active {
-		background: #007acc;
-		border-color: #007acc;
-		color: white;
-	}
-
-	/* Padding controls */
-	.padding-controls {
-		display: flex;
-		align-items: center;
-		gap: 1.5rem;
-		flex-wrap: wrap;
-	}
-
-	.slider-group {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		flex: 1;
-		min-width: 200px;
-	}
-
-	.slider-group input[type="range"] {
-		flex: 1;
-		height: 6px;
-		border-radius: 3px;
-		background: #e2e8f0;
-		appearance: none;
-		cursor: pointer;
-	}
-
-	.slider-group input[type="range"]::-webkit-slider-thumb {
-		appearance: none;
-		width: 18px;
-		height: 18px;
-		border-radius: 50%;
-		background: #007acc;
-		cursor: pointer;
-	}
-
-	.slider-group input[type="range"]::-moz-range-thumb {
-		width: 18px;
-		height: 18px;
-		border-radius: 50%;
-		background: #007acc;
-		cursor: pointer;
-		border: none;
-	}
-
-	.slider-value {
-		min-width: 40px;
-		text-align: right;
-		font-size: 0.9rem;
-		color: #718096;
-		font-variant-numeric: tabular-nums;
-	}
-
-	.color-picker {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.color-picker input[type="color"] {
-		width: 40px;
-		height: 32px;
-		border: 1px solid #e2e8f0;
-		border-radius: 6px;
-		cursor: pointer;
-		padding: 2px;
-	}
-
-	/* Padding mode section */
-	.padding-mode-section {
-		margin-top: 1rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-	}
-
-	/* Pixelation warning */
-	.pixelation-warning {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		margin-top: 1rem;
-		padding: 0.75rem 1rem;
-		background: #fffaf0;
-		border: 1px solid #ed8936;
-		border-radius: 8px;
-		color: #c05621;
-		font-size: 0.9rem;
-	}
-
-	.warning-icon {
-		font-size: 1.1rem;
-	}
-
-	/* Section header */
-	.section-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 1rem;
-	}
-
-	.section-header h2 {
-		margin-bottom: 0;
-	}
-
-	.preview-resolution {
-		font-size: 0.9rem;
-		color: #718096;
-	}
-
-	/* Carousel preview */
-	.carousel-preview {
-		display: flex;
-		gap: 0.5rem;
-		overflow-x: auto;
-		padding: 1rem 0;
-		scroll-snap-type: x mandatory;
-		-webkit-overflow-scrolling: touch;
-	}
-
-	.carousel-slide {
-		position: relative;
-		flex-shrink: 0;
-		width: 280px;
-		border-radius: 8px;
-		overflow: hidden;
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-		scroll-snap-align: start;
-	}
-
-	.carousel-slide img {
-		width: 100%;
-		height: auto;
-		display: block;
-	}
-
-	.slide-number {
-		position: absolute;
-		bottom: 0.5rem;
-		left: 0.5rem;
-		background: rgba(0, 0, 0, 0.6);
-		color: white;
-		font-size: 0.75rem;
-		padding: 0.2rem 0.5rem;
-		border-radius: 4px;
-	}
-
-	.carousel-hint {
-		font-size: 0.85rem;
-		margin-bottom: 1.5rem;
-	}
-
-	/* Preview grid */
-	.preview-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-		gap: 1rem;
-	}
-
-	.preview-item {
-		position: relative;
-		border-radius: 8px;
-		overflow: hidden;
-		background: #f7fafc;
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-	}
-
-	.preview-item img {
-		width: 100%;
-		height: auto;
-		display: block;
-	}
-
-	.image-number {
-		position: absolute;
-		bottom: 0.5rem;
-		left: 0.5rem;
-		background: rgba(0, 0, 0, 0.6);
-		color: white;
-		font-size: 0.85rem;
-		padding: 0.25rem 0.5rem;
-		border-radius: 4px;
-	}
-
-	/* Large button */
-	.btn-large {
-		padding: 1rem 2rem;
-		font-size: 1.1rem;
-	}
-
-	.hint {
-		margin-top: 0.75rem;
-		font-size: 0.9rem;
-	}
-
-	.mt-2 {
-		margin-top: 1.5rem;
-	}
-
-	/* Responsive */
-	@media (max-width: 600px) {
-		.split-count-buttons {
-			gap: 0.4rem;
-		}
-
-		.count-btn {
-			padding: 0.4rem 0.75rem;
-			min-width: 40px;
-		}
-
-		.carousel-slide {
-			width: 220px;
-		}
-
-		.preview-grid {
-			grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-		}
-
-		.padding-controls {
-			flex-direction: column;
-			align-items: flex-start;
-		}
-
-		.slider-group {
-			width: 100%;
-		}
-	}
-</style>

--- a/src/routes/tools/pdf-imposition/+page.svelte
+++ b/src/routes/tools/pdf-imposition/+page.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
 	import { resolve as resolvePath } from "$app/paths";
+	import { Button } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Checkbox } from "$lib/components/ui/checkbox";
+	import { Input } from "$lib/components/ui/input";
+	import { Label } from "$lib/components/ui/label";
+	import { Select } from "$lib/components/ui/select";
+	import { FileText, LayoutGrid, LoaderCircle, Upload, X } from "@lucide/svelte";
 	import { degrees, PDFDocument, rgb } from "pdf-lib";
 
 	let pdfFile: ArrayBuffer | null = $state(null);
@@ -407,357 +414,192 @@
 	<title>PDF Imposition Tool</title>
 </svelte:head>
 
-<main class="page-container">
-	<a href={resolvePath("/")} class="back-link">← Back to Tools</a>
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
 
-	<h1>📄 PDF N-Up Layout Generator</h1>
-	<p class="subtitle">Combine multiple PDF pages onto single sheets while preserving vector quality</p>
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight">
+		<LayoutGrid class="text-primary size-7" />
+		PDF N-Up Layout Generator
+	</h1>
+	<p class="text-muted-foreground mb-8">Combine multiple PDF pages onto single sheets while preserving vector quality</p>
 
-	<section class="mb-3">
-		<div
-			class="drop-zone"
-			class:has-file={pdfFile}
+	{#if pdfFile}
+		<div class="border-input bg-muted/40 mb-4 flex items-center gap-3 rounded-xl border p-4">
+			<FileText class="text-primary size-8 shrink-0" />
+			<div class="flex min-w-0 flex-col">
+				<span class="truncate font-semibold">{fileName}</span>
+				<span class="text-sm text-emerald-600 dark:text-emerald-400">{originalPageCount} page{originalPageCount !== 1 ? "s" : ""}</span>
+			</div>
+			<Button variant="ghost" size="icon" class="ml-auto" onclick={clearFile}><X class="size-4" /></Button>
+		</div>
+	{:else}
+		<label
+			class="border-input hover:border-ring hover:bg-accent bg-muted/40 mb-4 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
 			ondrop={handleDrop}
 			ondragover={handleDragOver}
-			role="button"
-			tabindex="0"
 		>
-			{#if pdfFile}
-				<div class="file-info">
-					<span class="file-icon">📄</span>
-					<div class="file-details">
-						<span class="file-name">{fileName}</span>
-						<span class="text-success">{originalPageCount} page{originalPageCount !== 1 ? "s" : ""}</span>
-					</div>
-					<button class="clear-btn" onclick={(e) => {
-						e.stopPropagation();
-						clearFile();
-					}}>✕</button>
-				</div>
-			{:else}
-				<div class="drop-content">
-					<span class="upload-icon">📥</span>
-					<p>Drag & drop a PDF here</p>
-					<p class="text-muted">or</p>
-					<label class="btn btn-primary">
-						Browse Files
-						<input type="file" accept=".pdf" onchange={handleFileSelect} hidden />
-					</label>
-				</div>
-			{/if}
-		</div>
-	</section>
-
-	<section class="card-section">
-		<h2>Layout Settings</h2>
-
-		<div class="settings-grid">
-			<div class="setting-group">
-				<label for="columns">Columns</label>
-				<input id="columns" type="number" bind:value={columns} min="1" max="10" />
-			</div>
-
-			<div class="setting-group">
-				<label for="rows">Rows</label>
-				<input id="rows" type="number" bind:value={rows} min="1" max="10" />
-			</div>
-
-			<div class="setting-group">
-				<label for="pageOrder">Page Order</label>
-				<select id="pageOrder" bind:value={pageOrder}>
-					<option value="row">Left to Right, Top to Bottom (Z)</option>
-					<option value="column">Top to Bottom, Left to Right (N)</option>
-				</select>
-			</div>
-
-			<div class="setting-group">
-				<label for="outputSize">Output Page Size</label>
-				<select id="outputSize" bind:value={outputSize}>
-					<option value="same">Auto (Scale from source)</option>
-					<option value="a4">A4 (210 × 297 mm)</option>
-					<option value="a3">A3 (297 × 420 mm)</option>
-					<option value="letter">Letter (8.5 × 11 in)</option>
-					<option value="legal">Legal (8.5 × 14 in)</option>
-					<option value="tabloid">Tabloid (11 × 17 in)</option>
-				</select>
-			</div>
-
-			<div class="setting-group">
-				<label for="margin">Outer Margin (mm)</label>
-				<input id="margin" type="number" bind:value={margin} min="0" max="25" step="0.5" />
-			</div>
-
-			<div class="setting-group">
-				<label for="gap">Inner Gap (mm)</label>
-				<input id="gap" type="number" bind:value={gap} min="0" max="25" step="0.5" />
-			</div>
-		</div>
-
-		<div class="checkbox-grid">
-			<label class="checkbox-label">
-				<input type="checkbox" bind:checked={repeatPages} />
-				<span>Repeat each page to fill sheet</span>
-			</label>
-			<label class="checkbox-label">
-				<input type="checkbox" bind:checked={resizeToFit} />
-				<span>Resize pages to fill space</span>
-			</label>
-			<label class="checkbox-label">
-				<input type="checkbox" bind:checked={autoRotate} />
-				<span>Auto-rotate pages to fit cells</span>
-			</label>
-			<label class="checkbox-label">
-				<input type="checkbox" bind:checked={showCropMarks} />
-				<span>Add crop marks</span>
-			</label>
-			<label class="checkbox-label">
-				<input type="checkbox" bind:checked={showBorders} />
-				<span>Add page borders</span>
-			</label>
-		</div>
-
-		<div class="preview-info card">
-			<div class="preview-box">
-				<div class="sheet-border" style="--cols: {columns}; --rows: {rows}; --gap: {Math.max(2, gap)}px;">
-					<div class="grid-preview">
-						{#each Array.from({ length: rows * columns }) as _, i (i)}
-							<div class="cell" class:has-cropmarks={showCropMarks}>
-								<div class="page-placeholder" class:has-border={showBorders}>{i + 1}</div>
-							</div>
-						{/each}
-					</div>
-				</div>
-			</div>
-			<div class="preview-text">
-				<p><strong>{nupPreview}</strong></p>
-				{#if originalPageCount > 0}
-					<p class="text-muted">
-						{originalPageCount} source pages → {estimatedOutputPages} output page{estimatedOutputPages !== 1 ? "s" : ""}
-					</p>
-				{/if}
-				<ul class="preview-options text-muted">
-					{#if repeatPages}<li>Each page repeated {columns * rows}×</li>{/if}
-					{#if resizeToFit}<li>Pages scaled to fit</li>{:else}<li>Original page size</li>{/if}
-					{#if gap > 0}<li>{gap} mm gap between pages</li>{/if}
-					{#if autoRotate}<li>Auto-rotation enabled</li>{/if}
-					{#if showBorders}<li>Page borders enabled</li>{/if}
-					{#if showCropMarks}<li>Crop marks included</li>{/if}
-				</ul>
-			</div>
-		</div>
-	</section>
-
-	{#if error}
-		<div class="error-message">⚠️ {error}</div>
+			<Upload class="text-muted-foreground size-9" />
+			<p class="font-medium">Drag & drop a PDF here</p>
+			<p class="text-muted-foreground text-sm">or click to browse</p>
+			<input type="file" accept=".pdf" onchange={handleFileSelect} hidden />
+		</label>
 	{/if}
 
-	<section class="text-center mb-3">
-		<button
-			class="btn btn-primary btn-large"
-			onclick={generateNupPdf}
-			disabled={!pdfFile || processing}
-		>
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Layout Settings</Card.Title>
+		</Card.Header>
+		<Card.Content class="space-y-5">
+			<div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+				<div class="grid gap-1.5">
+					<Label for="columns">Columns</Label>
+					<Input id="columns" type="number" bind:value={columns} min={1} max={10} />
+				</div>
+				<div class="grid gap-1.5">
+					<Label for="rows">Rows</Label>
+					<Input id="rows" type="number" bind:value={rows} min={1} max={10} />
+				</div>
+				<div class="grid gap-1.5">
+					<Label for="pageOrder">Page Order</Label>
+					<Select id="pageOrder" bind:value={pageOrder}>
+						<option value="row">Left to Right, Top to Bottom (Z)</option>
+						<option value="column">Top to Bottom, Left to Right (N)</option>
+					</Select>
+				</div>
+				<div class="grid gap-1.5">
+					<Label for="outputSize">Output Page Size</Label>
+					<Select id="outputSize" bind:value={outputSize}>
+						<option value="same">Auto (Scale from source)</option>
+						<option value="a4">A4 (210 × 297 mm)</option>
+						<option value="a3">A3 (297 × 420 mm)</option>
+						<option value="letter">Letter (8.5 × 11 in)</option>
+						<option value="legal">Legal (8.5 × 14 in)</option>
+						<option value="tabloid">Tabloid (11 × 17 in)</option>
+					</Select>
+				</div>
+				<div class="grid gap-1.5">
+					<Label for="margin">Outer Margin (mm)</Label>
+					<Input id="margin" type="number" bind:value={margin} min={0} max={25} step={0.5} />
+				</div>
+				<div class="grid gap-1.5">
+					<Label for="gap">Inner Gap (mm)</Label>
+					<Input id="gap" type="number" bind:value={gap} min={0} max={25} step={0.5} />
+				</div>
+			</div>
+
+			<div class="grid gap-3 sm:grid-cols-2">
+				<Label class="font-normal"><Checkbox bind:checked={repeatPages} /> Repeat each page to fill sheet</Label>
+				<Label class="font-normal"><Checkbox bind:checked={resizeToFit} /> Resize pages to fill space</Label>
+				<Label class="font-normal"><Checkbox bind:checked={autoRotate} /> Auto-rotate pages to fit cells</Label>
+				<Label class="font-normal"><Checkbox bind:checked={showCropMarks} /> Add crop marks</Label>
+				<Label class="font-normal"><Checkbox bind:checked={showBorders} /> Add page borders</Label>
+			</div>
+
+			<div class="bg-muted flex flex-wrap items-center gap-6 rounded-lg border p-4">
+				<div class="shrink-0">
+					<div class="sheet-border" style="--cols: {columns}; --rows: {rows}; --gap: {Math.max(2, gap)}px;">
+						<div class="grid-preview">
+							{#each Array.from({ length: rows * columns }) as _, i (i)}
+								<div class="cell" class:has-cropmarks={showCropMarks}>
+									<div class="page-placeholder" class:has-border={showBorders}>{i + 1}</div>
+								</div>
+							{/each}
+						</div>
+					</div>
+				</div>
+				<div>
+					<p class="mb-1 font-semibold">{nupPreview}</p>
+					{#if originalPageCount > 0}
+						<p class="text-muted-foreground text-sm">
+							{originalPageCount} source pages → {estimatedOutputPages} output page{estimatedOutputPages !== 1 ? "s" : ""}
+						</p>
+					{/if}
+					<ul class="text-muted-foreground mt-2 list-disc pl-5 text-sm">
+						{#if repeatPages}<li>Each page repeated {columns * rows}×</li>{/if}
+						{#if resizeToFit}<li>Pages scaled to fit</li>{:else}<li>Original page size</li>{/if}
+						{#if gap > 0}<li>{gap} mm gap between pages</li>{/if}
+						{#if autoRotate}<li>Auto-rotation enabled</li>{/if}
+						{#if showBorders}<li>Page borders enabled</li>{/if}
+						{#if showCropMarks}<li>Crop marks included</li>{/if}
+					</ul>
+				</div>
+			</div>
+		</Card.Content>
+	</Card.Root>
+
+	{#if error}
+		<div class="border-destructive/40 bg-destructive/10 text-destructive mb-4 rounded-lg border px-4 py-3 text-sm">⚠️ {error}</div>
+	{/if}
+
+	<div class="mb-4 text-center">
+		<Button size="lg" onclick={generateNupPdf} disabled={!pdfFile || processing}>
 			{#if processing}
-				<span class="spinner"></span>
+				<LoaderCircle class="size-4 animate-spin" />
 				Processing...
 			{:else}
-				🚀 Generate N-Up PDF
+				Generate N-Up PDF
 			{/if}
-		</button>
-	</section>
+		</Button>
+	</div>
 
-	<footer class="text-center text-muted">
+	<footer class="text-muted-foreground text-center text-sm">
 		<p>✨ Vector quality preserved • No server upload • Runs entirely in your browser</p>
 	</footer>
 </main>
 
 <style>
-  /* Tool-specific styles only */
-  .settings-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .setting-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-  }
-
-  .checkbox-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 0.75rem;
-    margin-bottom: 1.5rem;
-  }
-
-  .checkbox-label {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    cursor: pointer;
-    font-size: 0.95rem;
-  }
-
-  .checkbox-label input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    accent-color: #007acc;
-    cursor: pointer;
-  }
-
-  /* File upload specific */
-  .drop-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .upload-icon {
-    font-size: 3rem;
-  }
-
-  .file-info {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    justify-content: center;
-  }
-
-  .file-icon {
-    font-size: 2.5rem;
-  }
-
-  .file-details {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .file-name {
-    font-weight: 600;
-    word-break: break-all;
-  }
-
-  .clear-btn {
-    background: #e53e3e;
-    color: white;
-    border: none;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    cursor: pointer;
-    font-size: 1rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .clear-btn:hover {
-    background: #c53030;
-  }
-
-  /* Preview specific */
-  .preview-info {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-  }
-
-  .preview-box {
-    flex-shrink: 0;
-  }
-
-  .sheet-border {
-    width: 80px;
-    height: 110px;
-    background: white;
-    border: 2px solid #2d3748;
-    border-radius: 3px;
-    padding: 4px;
-    box-shadow: 2px 2px 8px rgba(0,0,0,0.1);
-  }
-
-  .grid-preview {
-    display: grid;
-    grid-template-columns: repeat(var(--cols), 1fr);
-    grid-template-rows: repeat(var(--rows), 1fr);
-		gap: var(--gap, 2px);
-    width: 100%;
-    height: 100%;
-  }
-
-  .cell {
-    background: #f7fafc;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 1px;
-    position: relative;
-  }
-
-  .cell.has-cropmarks::before {
-    content: '';
-    position: absolute;
-    width: 1px;
-    height: 4px;
-    top: -3px;
-    left: 0;
-    background: #e53e3e;
-  }
-
-  .page-placeholder {
-    width: 80%;
-    height: 80%;
-    background: white;
-    border: 1px solid #cbd5e0;
-    border-radius: 1px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.5rem;
-    color: #718096;
-  }
-
-	.page-placeholder.has-border {
-		border-color: #2d3748;
+	.sheet-border {
+		width: 80px;
+		height: 110px;
+		background: var(--background);
+		border: 2px solid var(--muted-foreground);
+		border-radius: 3px;
+		padding: 4px;
+		box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1);
 	}
 
-  .preview-text p {
-    margin-bottom: 0.3rem;
-  }
+	.grid-preview {
+		display: grid;
+		grid-template-columns: repeat(var(--cols), 1fr);
+		grid-template-rows: repeat(var(--rows), 1fr);
+		gap: var(--gap, 2px);
+		width: 100%;
+		height: 100%;
+	}
 
-  .preview-options {
-    margin-top: 0.5rem;
-    padding-left: 1.2rem;
-    font-size: 0.85rem;
-  }
+	.cell {
+		background: var(--muted);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 1px;
+		position: relative;
+	}
 
-  .preview-options li {
-    margin-bottom: 0.15rem;
-  }
+	.cell.has-cropmarks::before {
+		content: "";
+		position: absolute;
+		width: 1px;
+		height: 4px;
+		top: -3px;
+		left: 0;
+		background: #e53e3e;
+	}
 
-  /* Large button variant */
-  .btn-large {
-    padding: 1rem 2rem;
-    font-size: 1.1rem;
-  }
+	.page-placeholder {
+		width: 80%;
+		height: 80%;
+		background: var(--card);
+		border: 1px solid var(--border);
+		border-radius: 1px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 0.5rem;
+		color: var(--muted-foreground);
+	}
 
-  @media (max-width: 600px) {
-    .settings-grid {
-      grid-template-columns: 1fr 1fr;
-    }
-
-    .checkbox-grid {
-      grid-template-columns: 1fr;
-    }
-
-    .preview-info {
-      flex-direction: column;
-      text-align: center;
-    }
-  }
+	.page-placeholder.has-border {
+		border-color: var(--foreground);
+	}
 </style>

--- a/src/routes/tools/pdf-organizer/+page.svelte
+++ b/src/routes/tools/pdf-organizer/+page.svelte
@@ -1,0 +1,436 @@
+<script lang="ts">
+	import { resolve as resolvePath } from "$app/paths";
+	import { Button } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Checkbox } from "$lib/components/ui/checkbox";
+	import { Input } from "$lib/components/ui/input";
+	import { Select } from "$lib/components/ui/select";
+	import { cn } from "$lib/utils";
+	import { ChevronLeft, ChevronRight, FileStack, FileText, RotateCw, Trash2, Upload } from "@lucide/svelte";
+	import JSZip from "jszip";
+	import { degrees, PDFDocument } from "pdf-lib";
+	import { SvelteMap } from "svelte/reactivity";
+
+	type PageItem = {
+		id: string;
+		sourceId: string;
+		sourceName: string;
+		sourceIndex: number;
+		rotation: number;
+		selected: boolean;
+	};
+
+	type SplitMode = "individual" | "everyN" | "ranges";
+
+	const PDF_EXTENSION_RE = /\.pdf$/i;
+	const RANGE_RE = /^\d+(?:-\d+)?$/;
+
+	const sources = new SvelteMap<string, ArrayBuffer>();
+
+	let pages = $state<PageItem[]>([]);
+	let processing = $state(false);
+	let error = $state("");
+	let info = $state("");
+	let dragIndex = $state<number | null>(null);
+	let idCounter = 0;
+
+	let splitMode = $state<SplitMode>("individual");
+	let everyN = $state(1);
+	let rangesText = $state("");
+
+	const selectedCount = $derived(pages.filter(page => page.selected).length);
+	const baseName = $derived(
+		pages.length > 0 ? pages[0].sourceName.replace(PDF_EXTENSION_RE, "") : "document",
+	);
+
+	async function addFiles(fileList: FileList | null | undefined) {
+		if (!fileList || fileList.length === 0)
+			return;
+		error = "";
+		info = "";
+		const incoming = [...fileList].filter(file => file.type === "application/pdf" || PDF_EXTENSION_RE.test(file.name));
+		if (incoming.length === 0) {
+			error = "Please add valid PDF files";
+			return;
+		}
+
+		const added: PageItem[] = [];
+		for (const file of incoming) {
+			try {
+				const bytes = await file.arrayBuffer();
+				const doc = await PDFDocument.load(bytes);
+				const count = doc.getPageCount();
+				const sourceId = `src-${idCounter++}`;
+				sources.set(sourceId, bytes);
+				for (let i = 0; i < count; i++) {
+					added.push({
+						id: `pg-${idCounter++}`,
+						sourceId,
+						sourceName: file.name,
+						sourceIndex: i,
+						rotation: 0,
+						selected: false,
+					});
+				}
+			}
+			catch (e) {
+				error = `Failed to load ${file.name}: ${(e as Error).message}`;
+			}
+		}
+
+		pages = [...pages, ...added];
+	}
+
+	function handleFileSelect(event: Event) {
+		const target = event.target as HTMLInputElement;
+		void addFiles(target.files);
+		target.value = "";
+	}
+
+	function handleDrop(event: DragEvent) {
+		event.preventDefault();
+		void addFiles(event.dataTransfer?.files);
+	}
+
+	function handleDragOver(event: DragEvent) {
+		event.preventDefault();
+	}
+
+	function rotatePage(id: string) {
+		const page = pages.find(item => item.id === id);
+		if (page)
+			page.rotation = (page.rotation + 90) % 360;
+	}
+
+	function removePage(id: string) {
+		pages = pages.filter(item => item.id !== id);
+	}
+
+	function movePage(index: number, delta: number) {
+		const target = index + delta;
+		if (target < 0 || target >= pages.length)
+			return;
+		const next = [...pages];
+		[next[index], next[target]] = [next[target], next[index]];
+		pages = next;
+	}
+
+	function onCardDragStart(index: number) {
+		dragIndex = index;
+	}
+
+	function onCardDrop(index: number) {
+		if (dragIndex === null || dragIndex === index) {
+			dragIndex = null;
+			return;
+		}
+		const next = [...pages];
+		const [moved] = next.splice(dragIndex, 1);
+		next.splice(index, 0, moved);
+		pages = next;
+		dragIndex = null;
+	}
+
+	function toggleSelect(id: string) {
+		const page = pages.find(item => item.id === id);
+		if (page)
+			page.selected = !page.selected;
+	}
+
+	function selectAll() {
+		for (const page of pages)
+			page.selected = true;
+	}
+
+	function clearSelection() {
+		for (const page of pages)
+			page.selected = false;
+	}
+
+	function clearAll() {
+		pages = [];
+		sources.clear();
+		error = "";
+		info = "";
+	}
+
+	async function buildPdf(items: PageItem[]): Promise<Uint8Array> {
+		const out = await PDFDocument.create();
+		const cache = new SvelteMap<string, PDFDocument>();
+		for (const item of items) {
+			let srcDoc = cache.get(item.sourceId);
+			if (!srcDoc) {
+				const bytes = sources.get(item.sourceId);
+				if (!bytes)
+					continue;
+				srcDoc = await PDFDocument.load(bytes);
+				cache.set(item.sourceId, srcDoc);
+			}
+			const [copied] = await out.copyPages(srcDoc, [item.sourceIndex]);
+			if (item.rotation !== 0) {
+				const base = copied.getRotation().angle;
+				copied.setRotation(degrees((base + item.rotation) % 360));
+			}
+			out.addPage(copied);
+		}
+		return out.save();
+	}
+
+	function downloadBlob(blob: Blob, name: string) {
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = name;
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
+	}
+
+	function downloadPdf(bytes: Uint8Array, name: string) {
+		downloadBlob(new Blob([new Uint8Array(bytes)], { type: "application/pdf" }), name);
+	}
+
+	async function mergeDownload() {
+		if (pages.length === 0)
+			return;
+		processing = true;
+		error = "";
+		info = "";
+		try {
+			const bytes = await buildPdf(pages);
+			downloadPdf(bytes, `${baseName}_merged.pdf`);
+			info = `Saved ${pages.length} page${pages.length === 1 ? "" : "s"} to one PDF.`;
+		}
+		catch (e) {
+			error = `Failed to build PDF: ${(e as Error).message}`;
+		}
+		finally {
+			processing = false;
+		}
+	}
+
+	async function downloadSelected() {
+		const selected = pages.filter(page => page.selected);
+		if (selected.length === 0)
+			return;
+		processing = true;
+		error = "";
+		info = "";
+		try {
+			const bytes = await buildPdf(selected);
+			downloadPdf(bytes, `${baseName}_extract.pdf`);
+			info = `Extracted ${selected.length} selected page${selected.length === 1 ? "" : "s"}.`;
+		}
+		catch (e) {
+			error = `Failed to extract pages: ${(e as Error).message}`;
+		}
+		finally {
+			processing = false;
+		}
+	}
+
+	function parseRanges(text: string, max: number): { label: string; items: PageItem[] }[] {
+		const groups: { label: string; items: PageItem[] }[] = [];
+		for (const rawPart of text.split(",")) {
+			const part = rawPart.trim();
+			if (!part)
+				continue;
+			if (!RANGE_RE.test(part))
+				throw new Error(`Invalid range: "${part}"`);
+			const [startStr, endStr] = part.split("-");
+			const start = Number.parseInt(startStr, 10);
+			const end = endStr === undefined ? start : Number.parseInt(endStr, 10);
+			if (start < 1 || end > max || start > end)
+				throw new Error(`Range "${part}" is out of bounds (1-${max})`);
+			const items = pages.slice(start - 1, end);
+			groups.push({ label: start === end ? `${start}` : `${start}-${end}`, items });
+		}
+		if (groups.length === 0)
+			throw new Error("Enter at least one page range");
+		return groups;
+	}
+
+	function buildSplitGroups(): { label: string; items: PageItem[] }[] {
+		if (splitMode === "individual")
+			return pages.map((page, index) => ({ label: String(index + 1).padStart(2, "0"), items: [page] }));
+
+		if (splitMode === "everyN") {
+			const size = Math.max(1, Math.floor(Number(everyN) || 1));
+			const groups: { label: string; items: PageItem[] }[] = [];
+			for (let offset = 0; offset < pages.length; offset += size) {
+				const items = pages.slice(offset, offset + size);
+				const from = offset + 1;
+				const to = offset + items.length;
+				groups.push({ label: from === to ? `${from}` : `${from}-${to}`, items });
+			}
+			return groups;
+		}
+
+		return parseRanges(rangesText, pages.length);
+	}
+
+	async function splitDownload() {
+		if (pages.length === 0)
+			return;
+		processing = true;
+		error = "";
+		info = "";
+		try {
+			const groups = buildSplitGroups();
+			if (groups.length === 1) {
+				const bytes = await buildPdf(groups[0].items);
+				downloadPdf(bytes, `${baseName}_pages_${groups[0].label}.pdf`);
+				info = "Only one output file — downloaded directly.";
+				return;
+			}
+
+			const zip = new JSZip();
+			for (const group of groups) {
+				const bytes = await buildPdf(group.items);
+				zip.file(`${baseName}_pages_${group.label}.pdf`, bytes);
+			}
+			const blob = await zip.generateAsync({ type: "blob" });
+			downloadBlob(blob, `${baseName}_split.zip`);
+			info = `Split into ${groups.length} files (zipped).`;
+		}
+		catch (e) {
+			error = (e as Error).message || "Failed to split PDF";
+		}
+		finally {
+			processing = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>PDF Organizer</title>
+</svelte:head>
+
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
+
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight">
+		<FileStack class="text-primary size-7" />
+		PDF Organizer
+	</h1>
+	<p class="text-muted-foreground mb-8">Merge, split, reorder, rotate, and extract PDF pages — all in your browser.</p>
+
+	<label
+		class="border-input hover:border-ring hover:bg-accent bg-muted/40 mb-4 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
+		ondrop={handleDrop}
+		ondragover={handleDragOver}
+	>
+		<Upload class="text-muted-foreground size-9" />
+		<p class="font-medium">Drag & drop one or more PDFs here</p>
+		<p class="text-muted-foreground text-sm">or click to browse</p>
+		<input type="file" accept=".pdf" multiple onchange={handleFileSelect} hidden />
+	</label>
+
+	{#if error}
+		<div class="border-destructive/40 bg-destructive/10 text-destructive mb-4 rounded-lg border px-4 py-3 text-sm">⚠️ {error}</div>
+	{/if}
+	{#if info && !error}
+		<div class="mb-4 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-400">✅ {info}</div>
+	{/if}
+
+	{#if pages.length > 0}
+		<Card.Root class="mb-6">
+			<Card.Header class="flex-row flex-wrap items-center justify-between gap-3 space-y-0">
+				<Card.Title>Pages ({pages.length})</Card.Title>
+				<div class="flex flex-wrap gap-2">
+					<Button variant="outline" size="sm" onclick={selectAll}>Select All</Button>
+					<Button variant="outline" size="sm" onclick={clearSelection}>Clear Selection</Button>
+					<Button variant="outline" size="sm" onclick={clearAll}>Remove All</Button>
+				</div>
+			</Card.Header>
+			<Card.Content>
+				<p class="text-muted-foreground mb-4 text-sm">Drag cards to reorder. Rotate or delete individual pages, or tick pages to extract them.</p>
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-3">
+					{#each pages as page, index (page.id)}
+						<article
+							class={cn(
+								"bg-card flex cursor-grab flex-col gap-2 rounded-lg border p-2.5",
+								page.selected ? "border-primary ring-primary/20 ring-2" : "border-border",
+								dragIndex === index && "opacity-50",
+							)}
+							draggable="true"
+							ondragstart={() => onCardDragStart(index)}
+							ondragover={handleDragOver}
+							ondrop={() => onCardDrop(index)}
+							ondragend={() => (dragIndex = null)}
+						>
+							<div class="flex items-center gap-2 text-sm">
+								<Checkbox checked={page.selected} onCheckedChange={() => toggleSelect(page.id)} />
+								<span class="font-semibold">{index + 1}</span>
+							</div>
+							<div class="bg-muted grid h-[90px] place-items-center rounded-md border transition-transform" style="transform: rotate({page.rotation}deg);">
+								<FileText class="text-muted-foreground size-9" />
+							</div>
+							<div class="flex min-w-0 flex-col text-xs">
+								<span class="truncate" title={page.sourceName}>{page.sourceName}</span>
+								<span class="text-muted-foreground">p{page.sourceIndex + 1}{page.rotation ? ` · ${page.rotation}°` : ""}</span>
+							</div>
+							<div class="grid grid-cols-4 gap-1">
+								<Button variant="outline" size="icon" class="size-7" title="Move left" onclick={() => movePage(index, -1)} disabled={index === 0}><ChevronLeft class="size-4" /></Button>
+								<Button variant="outline" size="icon" class="size-7" title="Rotate 90°" onclick={() => rotatePage(page.id)}><RotateCw class="size-4" /></Button>
+								<Button variant="outline" size="icon" class="hover:bg-destructive/10 hover:text-destructive size-7" title="Delete page" onclick={() => removePage(page.id)}><Trash2 class="size-4" /></Button>
+								<Button variant="outline" size="icon" class="size-7" title="Move right" onclick={() => movePage(index, 1)} disabled={index === pages.length - 1}><ChevronRight class="size-4" /></Button>
+							</div>
+						</article>
+					{/each}
+				</div>
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>Export</Card.Title>
+			</Card.Header>
+			<Card.Content class="divide-border divide-y">
+				<div class="flex flex-wrap items-center justify-between gap-3 pb-4">
+					<div>
+						<h3 class="font-semibold">Merge / Save</h3>
+						<p class="text-muted-foreground text-sm">Save every page in the current order as a single PDF.</p>
+					</div>
+					<Button onclick={mergeDownload} disabled={processing}>Save PDF ({pages.length})</Button>
+				</div>
+
+				<div class="flex flex-wrap items-center justify-between gap-3 py-4">
+					<div>
+						<h3 class="font-semibold">Extract Selected</h3>
+						<p class="text-muted-foreground text-sm">Save only the ticked pages as one PDF.</p>
+					</div>
+					<Button variant="outline" onclick={downloadSelected} disabled={processing || selectedCount === 0}>Extract Selected ({selectedCount})</Button>
+				</div>
+
+				<div class="flex flex-wrap items-center justify-between gap-3 pt-4">
+					<div class="min-w-[220px] flex-1">
+						<h3 class="font-semibold">Split</h3>
+						<div class="my-2 flex flex-wrap gap-2">
+							<div class="w-52">
+								<Select bind:value={splitMode} aria-label="Split mode">
+									<option value="individual">Each page separately</option>
+									<option value="everyN">Every N pages</option>
+									<option value="ranges">Custom ranges</option>
+								</Select>
+							</div>
+							{#if splitMode === "everyN"}
+								<div class="w-40"><Input type="number" min={1} max={pages.length} bind:value={everyN} aria-label="Pages per file" /></div>
+							{/if}
+							{#if splitMode === "ranges"}
+								<div class="w-52"><Input type="text" bind:value={rangesText} placeholder="e.g. 1-3, 4, 5-8" aria-label="Page ranges" /></div>
+							{/if}
+						</div>
+						<p class="text-muted-foreground text-sm">Multiple output files are delivered as a ZIP.</p>
+					</div>
+					<Button onclick={splitDownload} disabled={processing}>Split & Download</Button>
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+
+	<footer class="text-muted-foreground mt-8 text-center text-sm">
+		<p>✨ No server upload • Runs entirely in your browser</p>
+	</footer>
+</main>

--- a/src/routes/tools/qr-code-generator/+page.svelte
+++ b/src/routes/tools/qr-code-generator/+page.svelte
@@ -1,0 +1,401 @@
+<script lang="ts">
+	import type QRCodeStyling from "qr-code-styling";
+	import { resolve as resolvePath } from "$app/paths";
+	import { Button, buttonVariants } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Checkbox } from "$lib/components/ui/checkbox";
+	import { Input } from "$lib/components/ui/input";
+	import { Label } from "$lib/components/ui/label";
+	import { Select } from "$lib/components/ui/select";
+	import { Slider } from "$lib/components/ui/slider";
+	import { cn } from "$lib/utils";
+	import { QrCode } from "@lucide/svelte";
+	import { onMount } from "svelte";
+
+	type DotType = "square" | "dots" | "rounded" | "extra-rounded" | "classy" | "classy-rounded";
+	type CornerSquareType = "square" | "dot" | "extra-rounded";
+	type CornerDotType = "square" | "dot";
+	type ErrorLevel = "L" | "M" | "Q" | "H";
+	type Extension = "png" | "jpeg" | "svg";
+
+	const dotTypes: { value: DotType; label: string }[] = [
+		{ value: "square", label: "Square" },
+		{ value: "dots", label: "Dots" },
+		{ value: "rounded", label: "Rounded" },
+		{ value: "extra-rounded", label: "Extra Rounded" },
+		{ value: "classy", label: "Classy" },
+		{ value: "classy-rounded", label: "Classy Rounded" },
+	];
+
+	const cornerSquareTypes: { value: CornerSquareType; label: string }[] = [
+		{ value: "square", label: "Square" },
+		{ value: "dot", label: "Dot" },
+		{ value: "extra-rounded", label: "Extra Rounded" },
+	];
+
+	const cornerDotTypes: { value: CornerDotType; label: string }[] = [
+		{ value: "square", label: "Square" },
+		{ value: "dot", label: "Dot" },
+	];
+
+	const errorLevels: { value: ErrorLevel; label: string }[] = [
+		{ value: "L", label: "Low (7%)" },
+		{ value: "M", label: "Medium (15%)" },
+		{ value: "Q", label: "Quartile (25%)" },
+		{ value: "H", label: "High (30%)" },
+	];
+
+	let mode = $state<"basic" | "styled">("basic");
+	let data = $state("https://bevankay.me");
+	let size = $state(320);
+	let margin = $state(12);
+	let errorLevel = $state<ErrorLevel>("Q");
+
+	let dotType = $state<DotType>("rounded");
+	let dotColor = $state("#1a202c");
+	let useGradient = $state(false);
+	let dotColor2 = $state("#007acc");
+	let gradientType = $state<"linear" | "radial">("linear");
+	let gradientRotation = $state(0);
+
+	let bgColor = $state("#ffffff");
+	let transparentBg = $state(false);
+
+	let cornerSquareType = $state<CornerSquareType>("extra-rounded");
+	let cornerSquareColor = $state("#1a202c");
+	let cornerDotType = $state<CornerDotType>("dot");
+	let cornerDotColor = $state("#007acc");
+
+	let logoDataUrl = $state<string | null>(null);
+	let logoName = $state("");
+	let logoSize = $state(0.4);
+	let logoMargin = $state(6);
+	let hideBackgroundDots = $state(true);
+
+	let downloadExtension = $state<Extension>("png");
+
+	let previewEl = $state<HTMLDivElement>();
+	let qrCode = $state<QRCodeStyling | null>(null);
+	let QrCtor = $state<typeof QRCodeStyling | null>(null);
+
+	function buildOptions() {
+		const base = {
+			width: size,
+			height: size,
+			type: "canvas" as const,
+			data: data.trim() || " ",
+			margin,
+			qrOptions: { errorCorrectionLevel: errorLevel },
+		};
+
+		if (mode === "basic") {
+			return {
+				...base,
+				image: undefined,
+				dotsOptions: { type: "square" as DotType, color: "#000000", gradient: undefined },
+				backgroundOptions: { color: "#ffffff" },
+				cornersSquareOptions: { type: "square" as CornerSquareType, color: "#000000" },
+				cornersDotOptions: { type: "square" as CornerDotType, color: "#000000" },
+				imageOptions: { crossOrigin: "anonymous" as const, margin: 0, imageSize: 0.4, hideBackgroundDots: true },
+			};
+		}
+
+		const gradient = useGradient
+			? {
+				type: gradientType,
+				rotation: (gradientRotation * Math.PI) / 180,
+				colorStops: [
+					{ offset: 0, color: dotColor },
+					{ offset: 1, color: dotColor2 },
+				],
+			}
+			: undefined;
+
+		return {
+			...base,
+			image: logoDataUrl ?? undefined,
+			dotsOptions: {
+				type: dotType,
+				color: useGradient ? undefined : dotColor,
+				gradient,
+			},
+			backgroundOptions: {
+				color: transparentBg ? "transparent" : bgColor,
+			},
+			cornersSquareOptions: {
+				type: cornerSquareType,
+				color: cornerSquareColor,
+			},
+			cornersDotOptions: {
+				type: cornerDotType,
+				color: cornerDotColor,
+			},
+			imageOptions: {
+				crossOrigin: "anonymous" as const,
+				margin: logoMargin,
+				imageSize: logoSize,
+				hideBackgroundDots,
+			},
+		};
+	}
+
+	onMount(async () => {
+		const mod = await import("qr-code-styling");
+		QrCtor = mod.default;
+		qrCode = new QrCtor(buildOptions());
+		if (previewEl)
+			qrCode.append(previewEl);
+	});
+
+	$effect(() => {
+		const options = buildOptions();
+		if (qrCode)
+			qrCode.update(options);
+	});
+
+	function onLogoChange(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file)
+			return;
+		logoName = file.name;
+		const reader = new FileReader();
+		reader.onload = () => {
+			logoDataUrl = typeof reader.result === "string" ? reader.result : null;
+		};
+		reader.readAsDataURL(file);
+	}
+
+	function removeLogo() {
+		logoDataUrl = null;
+		logoName = "";
+	}
+
+	async function download() {
+		if (!QrCtor || !data.trim())
+			return;
+		const type = downloadExtension === "svg" ? "svg" : "canvas";
+		const instance = new QrCtor({ ...buildOptions(), type });
+		await instance.download({ name: "qr-code", extension: downloadExtension });
+	}
+
+	const colorInputClass = "border-input h-9 w-full cursor-pointer rounded-md border bg-transparent p-1";
+	const fieldClass = "grid gap-1.5";
+</script>
+
+<svelte:head>
+	<title>QR Code Generator</title>
+</svelte:head>
+
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
+
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight">
+		<QrCode class="text-primary size-7" />
+		QR Code Generator
+	</h1>
+	<p class="text-muted-foreground mb-8">Create custom QR codes with your own colors, dot styles, and logo.</p>
+
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Content</Card.Title>
+		</Card.Header>
+		<Card.Content class={fieldClass}>
+			<Label for="qr-data">Text or URL to encode</Label>
+			<Input id="qr-data" type="text" bind:value={data} placeholder="https://example.com" />
+		</Card.Content>
+	</Card.Root>
+
+	<div class="grid items-start gap-6 md:grid-cols-[1fr_340px]">
+		<Card.Root>
+			<Card.Content class="space-y-4">
+				<div class="bg-muted grid grid-cols-2 gap-1 rounded-lg p-1">
+					<Button variant={mode === "basic" ? "default" : "ghost"} size="sm" onclick={() => (mode = "basic")}>Basic</Button>
+					<Button variant={mode === "styled" ? "default" : "ghost"} size="sm" onclick={() => (mode = "styled")}>Styled</Button>
+				</div>
+				{#if mode === "basic"}
+					<p class="text-muted-foreground text-sm">Plain black-and-white QR code. Switch to Styled to customise colors, shapes, and add a logo.</p>
+				{/if}
+
+				<div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+					<div class={fieldClass}>
+						<Label for="qr-size">Size (px)</Label>
+						<Input id="qr-size" type="number" min={120} max={1024} step={8} bind:value={size} />
+					</div>
+					<div class={fieldClass}>
+						<Label for="qr-margin">Margin (px)</Label>
+						<Input id="qr-margin" type="number" min={0} max={80} step={1} bind:value={margin} />
+					</div>
+					<div class={fieldClass}>
+						<Label for="qr-ec">Error correction</Label>
+						<Select id="qr-ec" bind:value={errorLevel}>
+							{#each errorLevels as level (level.value)}
+								<option value={level.value}>{level.label}</option>
+							{/each}
+						</Select>
+					</div>
+				</div>
+
+				{#if mode === "styled"}
+					<div>
+						<h3 class="text-foreground mb-2 text-sm font-semibold">Dots</h3>
+						<div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+							<div class={fieldClass}>
+								<Label for="qr-dot-type">Dot style</Label>
+								<Select id="qr-dot-type" bind:value={dotType}>
+									{#each dotTypes as option (option.value)}
+										<option value={option.value}>{option.label}</option>
+									{/each}
+								</Select>
+							</div>
+							<div class={fieldClass}>
+								<Label for="qr-dot-color">{useGradient ? "Gradient start" : "Dot color"}</Label>
+								<input id="qr-dot-color" type="color" bind:value={dotColor} class={colorInputClass} />
+							</div>
+							{#if useGradient}
+								<div class={fieldClass}>
+									<Label for="qr-dot-color-2">Gradient end</Label>
+									<input id="qr-dot-color-2" type="color" bind:value={dotColor2} class={colorInputClass} />
+								</div>
+							{/if}
+						</div>
+					</div>
+
+					<div class="flex items-center gap-2">
+						<Checkbox id="use-gradient" bind:checked={useGradient} />
+						<Label for="use-gradient">Use gradient fill</Label>
+					</div>
+
+					{#if useGradient}
+						<div class="grid grid-cols-2 gap-3">
+							<div class={fieldClass}>
+								<Label for="qr-grad-type">Gradient type</Label>
+								<Select id="qr-grad-type" bind:value={gradientType}>
+									<option value="linear">Linear</option>
+									<option value="radial">Radial</option>
+								</Select>
+							</div>
+							{#if gradientType === "linear"}
+								<div class={fieldClass}>
+									<Label for="qr-grad-rot">Rotation ({gradientRotation}°)</Label>
+									<div class="flex h-9 items-center"><Slider type="single" min={0} max={360} step={5} bind:value={gradientRotation} /></div>
+								</div>
+							{/if}
+						</div>
+					{/if}
+
+					<div>
+						<h3 class="text-foreground mb-2 text-sm font-semibold">Corners</h3>
+						<div class="grid grid-cols-2 gap-3">
+							<div class={fieldClass}>
+								<Label for="qr-cs-type">Corner frame</Label>
+								<Select id="qr-cs-type" bind:value={cornerSquareType}>
+									{#each cornerSquareTypes as option (option.value)}
+										<option value={option.value}>{option.label}</option>
+									{/each}
+								</Select>
+							</div>
+							<div class={fieldClass}>
+								<Label for="qr-cs-color">Frame color</Label>
+								<input id="qr-cs-color" type="color" bind:value={cornerSquareColor} class={colorInputClass} />
+							</div>
+							<div class={fieldClass}>
+								<Label for="qr-cd-type">Corner dot</Label>
+								<Select id="qr-cd-type" bind:value={cornerDotType}>
+									{#each cornerDotTypes as option (option.value)}
+										<option value={option.value}>{option.label}</option>
+									{/each}
+								</Select>
+							</div>
+							<div class={fieldClass}>
+								<Label for="qr-cd-color">Corner dot color</Label>
+								<input id="qr-cd-color" type="color" bind:value={cornerDotColor} class={colorInputClass} />
+							</div>
+						</div>
+					</div>
+
+					<div>
+						<h3 class="text-foreground mb-2 text-sm font-semibold">Background</h3>
+						<div class="grid grid-cols-2 gap-3">
+							<div class={fieldClass}>
+								<Label for="qr-bg-color">Background color</Label>
+								<input id="qr-bg-color" type="color" bind:value={bgColor} disabled={transparentBg} class={cn(colorInputClass, "disabled:opacity-50")} />
+							</div>
+						</div>
+						<div class="mt-3 flex items-center gap-2">
+							<Checkbox id="transparent-bg" bind:checked={transparentBg} />
+							<Label for="transparent-bg">Transparent background</Label>
+						</div>
+					</div>
+
+					<div>
+						<h3 class="text-foreground mb-2 text-sm font-semibold">Logo</h3>
+						<label for="qr-logo" class={cn(buttonVariants({ variant: "outline" }), "cursor-pointer")}>
+							{logoName ? "Change logo" : "Upload logo"}
+							<input id="qr-logo" type="file" accept="image/*" onchange={onLogoChange} hidden />
+						</label>
+						{#if logoDataUrl}
+							<div class="mt-3 flex items-center gap-3">
+								<img class="border-input bg-muted size-10 rounded-md border object-contain" src={logoDataUrl} alt="Logo preview" />
+								<span class="text-muted-foreground min-w-0 flex-1 truncate text-sm">{logoName}</span>
+								<Button variant="destructive" size="sm" onclick={removeLogo}>Remove</Button>
+							</div>
+							<div class="mt-3 grid grid-cols-2 gap-3">
+								<div class={fieldClass}>
+									<Label for="qr-logo-size">Logo size ({Math.round(logoSize * 100)}%)</Label>
+									<div class="flex h-9 items-center"><Slider type="single" min={0.1} max={0.6} step={0.05} bind:value={logoSize} /></div>
+								</div>
+								<div class={fieldClass}>
+									<Label for="qr-logo-margin">Logo margin (px)</Label>
+									<Input id="qr-logo-margin" type="number" min={0} max={40} step={1} bind:value={logoMargin} />
+								</div>
+							</div>
+							<div class="mt-3 flex items-center gap-2">
+								<Checkbox id="hide-bg-dots" bind:checked={hideBackgroundDots} />
+								<Label for="hide-bg-dots">Hide dots behind logo</Label>
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+
+		<Card.Root class="md:sticky md:top-4">
+			<Card.Header>
+				<Card.Title>Preview</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<div class="bg-card grid min-h-[200px] place-items-center rounded-xl border p-4" class:checker={mode === "styled" && transparentBg}>
+					<div bind:this={previewEl} class="[&_canvas]:h-auto [&_canvas]:max-w-full [&_svg]:h-auto [&_svg]:max-w-full"></div>
+				</div>
+
+				<div class="mt-4 flex gap-2">
+					<div class="w-24">
+						<Select bind:value={downloadExtension} aria-label="Download format">
+							<option value="png">PNG</option>
+							<option value="jpeg">JPEG</option>
+							<option value="svg">SVG</option>
+						</Select>
+					</div>
+					<Button class="flex-1" onclick={download} disabled={!data.trim()}>Download</Button>
+				</div>
+				{#if mode === "styled" && transparentBg && downloadExtension === "jpeg"}
+					<p class="text-muted-foreground mt-2 text-sm">JPEG has no transparency — the background will be filled.</p>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+	</div>
+</main>
+
+<style>
+	.checker {
+		background-color: #fff;
+		background-image:
+			linear-gradient(45deg, #e2e8f0 25%, transparent 25%),
+			linear-gradient(-45deg, #e2e8f0 25%, transparent 25%),
+			linear-gradient(45deg, transparent 75%, #e2e8f0 75%),
+			linear-gradient(-45deg, transparent 75%, #e2e8f0 75%);
+		background-size: 20px 20px;
+		background-position: 0 0, 0 10px, 10px -10px, -10px 0;
+	}
+</style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,20 @@
 import { sveltekit } from "@sveltejs/kit/vite";
+import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
+// Absolute filesystem path so the alias resolves correctly during dev
+// dependency optimization (a root-relative "/src/..." target is otherwise
+// treated as relative to the importing module inside node_modules).
+const mediapipeShim = new URL("./src/lib/shims/mediapipe-face-detection.js", import.meta.url).pathname;
+
 export default defineConfig({
-	plugins: [sveltekit()],
+	plugins: [tailwindcss(), sveltekit()],
 	resolve: {
 		alias: {
 			// The collage-creator only uses the tfjs face-detection runtime, so the
 			// MediaPipe solution is dead code. Its UMD bundle exposes no static
 			// `FaceDetection` export, which breaks rolldown (Vite 8); shim it out.
-			"@mediapipe/face_detection": "/src/lib/shims/mediapipe-face-detection.js",
+			"@mediapipe/face_detection": mediapipeShim,
 		},
 	},
 	optimizeDeps: {


### PR DESCRIPTION
## Summary

Adds two new tools and rebuilds the app UI on shadcn-svelte (Tailwind v4), with dark mode, Manrope, and a header tools menu.

### New tools
- **QR Code Generator** — Basic/Styled modes, recolour, dot/corner styles, gradients, logo, PNG/JPEG/SVG export.
- **PDF Organizer** — merge, split (each page / every N / ranges), reorder, rotate, extract; ZIP output.

### Design system
- Tailwind v4 + shadcn-svelte components: Button, Card, Input, Label, Checkbox, Select, Slider, DropdownMenu.
- Light/dark theme via `mode-watcher` with a header toggle; tokenised `global.css`.
- **Manrope** font (Google Fonts).
- Header **Tools menu** to jump between tools from any page (active item highlighted).
- Emoji replaced with Lucide icons throughout.

### Migrated to the new components
Home, QR Generator, PDF Organizer, Favicon Extractor, PDF Imposition, Batch Image Compressor, Panorama Splitter, Collage Creator, Instagram Carousel.

### Fixes
- Dev-server crash from the MediaPipe shim alias (now an absolute path).
- Fragile `resolve()` cast on the home page.

Version bumped to **3.0.0**. `check` and `lint` pass; static build prerenders all pages.
