### PR TITLE
Match app colours to bevankay.me

### DIFF
--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -5,47 +5,47 @@
 
 :root {
 	--radius: 0.625rem;
-	--background: oklch(1 0 0);
-	--foreground: oklch(0.145 0 0);
-	--card: oklch(1 0 0);
-	--card-foreground: oklch(0.145 0 0);
-	--popover: oklch(1 0 0);
-	--popover-foreground: oklch(0.145 0 0);
-	--primary: oklch(0.55 0.16 240);
-	--primary-foreground: oklch(0.985 0 0);
-	--secondary: oklch(0.97 0 0);
-	--secondary-foreground: oklch(0.205 0 0);
-	--muted: oklch(0.97 0 0);
-	--muted-foreground: oklch(0.556 0 0);
-	--accent: oklch(0.97 0 0);
-	--accent-foreground: oklch(0.205 0 0);
-	--destructive: oklch(0.577 0.245 27.325);
-	--destructive-foreground: oklch(0.985 0 0);
-	--border: oklch(0.922 0 0);
-	--input: oklch(0.922 0 0);
-	--ring: oklch(0.55 0.16 240);
+	--background: #f8f8f9;
+	--foreground: #0f0f13;
+	--card: #ffffff;
+	--card-foreground: #0f0f13;
+	--popover: #ffffff;
+	--popover-foreground: #0f0f13;
+	--primary: #cf7022;
+	--primary-foreground: #ffffff;
+	--secondary: #f0f0f2;
+	--secondary-foreground: #2a2a33;
+	--muted: #f0f0f2;
+	--muted-foreground: #6e6e7a;
+	--accent: #fbefd9;
+	--accent-foreground: #0f0f13;
+	--destructive: #c2410c;
+	--destructive-foreground: #ffffff;
+	--border: #e4e4e7;
+	--input: #e4e4e7;
+	--ring: #e5a04b;
 }
 
 .dark {
-	--background: oklch(0.145 0 0);
-	--foreground: oklch(0.985 0 0);
-	--card: oklch(0.205 0 0);
-	--card-foreground: oklch(0.985 0 0);
-	--popover: oklch(0.205 0 0);
-	--popover-foreground: oklch(0.985 0 0);
-	--primary: oklch(0.7 0.15 240);
-	--primary-foreground: oklch(0.205 0 0);
-	--secondary: oklch(0.269 0 0);
-	--secondary-foreground: oklch(0.985 0 0);
-	--muted: oklch(0.269 0 0);
-	--muted-foreground: oklch(0.708 0 0);
-	--accent: oklch(0.269 0 0);
-	--accent-foreground: oklch(0.985 0 0);
-	--destructive: oklch(0.704 0.191 22.216);
-	--destructive-foreground: oklch(0.985 0 0);
-	--border: oklch(1 0 0 / 10%);
-	--input: oklch(1 0 0 / 15%);
-	--ring: oklch(0.7 0.15 240);
+	--background: #0c0c0f;
+	--foreground: #f8f8f9;
+	--card: #18181d;
+	--card-foreground: #f8f8f9;
+	--popover: #18181d;
+	--popover-foreground: #f8f8f9;
+	--primary: #e5a04b;
+	--primary-foreground: #0f0f13;
+	--secondary: #18181d;
+	--secondary-foreground: #f0f0f2;
+	--muted: #18181d;
+	--muted-foreground: #a0a0ab;
+	--accent: #2a2a33;
+	--accent-foreground: #f8f8f9;
+	--destructive: #f0c380;
+	--destructive-foreground: #0f0f13;
+	--border: #2a2a33;
+	--input: #2a2a33;
+	--ring: #e5a04b;
 }
 
 @theme inline {

--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -146,8 +146,8 @@ body {
 
 .drop-zone.has-file {
 	border-style: solid;
-	border-color: #48bb78;
-	background: #f0fff4;
+	border-color: var(--primary);
+	background: var(--accent);
 }
 
 /* Utility classes */
@@ -156,7 +156,7 @@ body {
 }
 
 .text-success {
-	color: #48bb78;
+	color: var(--primary);
 }
 
 .text-center {
@@ -169,8 +169,8 @@ body {
 
 /* Error message */
 .error-message {
-	background: #fed7d7;
-	color: #c53030;
+	background: color-mix(in oklab, var(--destructive) 12%, transparent);
+	color: var(--destructive);
 	padding: 1rem;
 	border-radius: 8px;
 	margin-bottom: 1.5rem;
@@ -181,8 +181,8 @@ body {
 .spinner {
 	width: 20px;
 	height: 20px;
-	border: 2px solid rgba(255, 255, 255, 0.3);
-	border-top-color: white;
+	border: 2px solid color-mix(in oklab, currentColor 30%, transparent);
+	border-top-color: currentColor;
 	border-radius: 50%;
 	animation: spin 0.8s linear infinite;
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -105,7 +105,7 @@
 		text-align: center;
 		padding: 0.5rem 1rem 0.75rem;
 		font-size: 0.75rem;
-		color: #718096;
+		color: var(--muted-foreground);
 	}
 
 	.footer-separator {


### PR DESCRIPTION
## Summary

- Update shared theme tokens to match the live bevankay.me surface and amber accent palette
- Replace remaining shared hard-coded footer, drop-zone, success, error, and spinner colors with theme-aware values

## Validation

- `pnpm lint`
- `pnpm check`
