### PR TITLE
Add image cropper and PDF compressor tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"jszip": "^3.10.1",
 		"mode-watcher": "^1.1.0",
 		"pdf-lib": "^1.17.1",
+		"pdfjs-dist": "^6.1.200",
 		"qr-code-styling": "^1.9.2",
 		"tailwind-merge": "^3.6.0",
 		"tailwind-variants": "^3.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
+      pdfjs-dist:
+        specifier: ^6.1.200
+        version: 6.1.200
       qr-code-styling:
         specifier: ^1.9.2
         version: 1.9.2
@@ -496,6 +499,81 @@ packages:
 
   '@mediapipe/face_detection@0.4.1646425229':
     resolution: {integrity: sha512-aeCN+fRAojv9ch3NXorP6r5tcGVLR3/gC1HmtqB0WEZBRXrdP6/3W/sGR0dHr1iT6ueiK95G9PVjbzFosf/hrg==}
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    resolution: {integrity: sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    resolution: {integrity: sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.2':
+    resolution: {integrity: sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -2099,6 +2177,10 @@ packages:
   pdf-lib@1.17.1:
     resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
+  pdfjs-dist@6.1.200:
+    resolution: {integrity: sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2888,6 +2970,54 @@ snapshots:
       svelte: 5.56.4(@typescript-eslint/types@8.60.0)
 
   '@mediapipe/face_detection@0.4.1646425229': {}
+
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@napi-rs/canvas@1.0.2':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-x64': 1.0.2
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.2
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.2
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-musl': 1.0.2
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.2
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.2
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -4597,6 +4727,10 @@ snapshots:
       '@pdf-lib/upng': 1.0.1
       pako: 1.0.11
       tslib: 1.14.1
+
+  pdfjs-dist@6.1.200:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.2
 
   picocolors@1.1.1: {}
 

--- a/src/lib/pdf-compress.ts
+++ b/src/lib/pdf-compress.ts
@@ -1,0 +1,497 @@
+import { PDFArray, PDFDict, PDFDocument, PDFName, PDFNumber, PDFRawStream, PDFRef } from "pdf-lib";
+
+let pdfjsPromise: Promise<typeof import("pdfjs-dist")> | null = null;
+async function getPdfjs() {
+	if (!pdfjsPromise) {
+		pdfjsPromise = (async () => {
+			const pdfjsLib = await import("pdfjs-dist");
+			const workerUrl = (await import("pdfjs-dist/build/pdf.worker.mjs?url")).default;
+			pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl;
+			return pdfjsLib;
+		})();
+	}
+	return pdfjsPromise;
+}
+
+async function canvasToBlob(canvas: HTMLCanvasElement, mime: string, quality: number): Promise<Blob> {
+	return new Promise((resolve, reject) => {
+		canvas.toBlob((blob) => {
+			if (!blob) {
+				reject(new Error("Failed to encode page image"));
+				return;
+			}
+			resolve(blob);
+		}, mime, quality);
+	});
+}
+
+// --- Aggressive: rasterize every page to a JPEG -----------------------------
+
+export async function rasterizePdf(bytes: ArrayBuffer, options: { dpi: number; quality: number }): Promise<Uint8Array> {
+	const pdfjsLib = await getPdfjs();
+	const scale = options.dpi / 72;
+	const qualityRatio = options.quality / 100;
+	const loadingTask = pdfjsLib.getDocument({ data: new Uint8Array(bytes) });
+	const pdf = await loadingTask.promise;
+	const out = await PDFDocument.create();
+
+	try {
+		for (let pageNum = 1; pageNum <= pdf.numPages; pageNum += 1) {
+			const page = await pdf.getPage(pageNum);
+			const baseViewport = page.getViewport({ scale: 1 });
+			const viewport = page.getViewport({ scale });
+			const canvas = document.createElement("canvas");
+			canvas.width = Math.max(1, Math.ceil(viewport.width));
+			canvas.height = Math.max(1, Math.ceil(viewport.height));
+			const ctx = canvas.getContext("2d");
+			if (!ctx)
+				throw new Error("Unable to create canvas context");
+			ctx.fillStyle = "#ffffff";
+			ctx.fillRect(0, 0, canvas.width, canvas.height);
+			await page.render({ canvas, canvasContext: ctx, viewport }).promise;
+
+			const jpegBlob = await canvasToBlob(canvas, "image/jpeg", qualityRatio);
+			const jpegBytes = await jpegBlob.arrayBuffer();
+			const image = await out.embedJpg(jpegBytes);
+			const outPage = out.addPage([baseViewport.width, baseViewport.height]);
+			outPage.drawImage(image, { x: 0, y: 0, width: baseViewport.width, height: baseViewport.height });
+			page.cleanup();
+		}
+	}
+	finally {
+		await loadingTask.destroy();
+	}
+
+	return out.save();
+}
+
+// --- Downsample: recompress JPEG image XObjects, keep text/vectors ----------
+
+function numberVal(dict: PDFDict, key: string) {
+	const value = dict.lookup(PDFName.of(key));
+	return value instanceof PDFNumber ? value.asNumber() : 0;
+}
+
+// Only handle streams whose bytes are a bare JPEG (single DCTDecode filter).
+function isPlainJpeg(dict: PDFDict) {
+	const filter = dict.lookup(PDFName.of("Filter"));
+	if (filter instanceof PDFName)
+		return filter.toString() === "/DCTDecode";
+	if (filter instanceof PDFArray)
+		return filter.size() === 1 && filter.lookup(0)?.toString() === "/DCTDecode";
+	return false;
+}
+
+// Restrict to colour spaces a browser canvas decodes correctly (→ RGB output).
+function colorSpaceSupported(dict: PDFDict) {
+	const cs = dict.lookup(PDFName.of("ColorSpace"));
+	if (cs instanceof PDFName) {
+		const name = cs.toString();
+		return name === "/DeviceRGB" || name === "/DeviceGray" || name === "/CalRGB" || name === "/CalGray";
+	}
+	if (cs instanceof PDFArray) {
+		const kind = cs.get(0)?.toString();
+		if (kind === "/ICCBased") {
+			const stream = cs.lookup(1);
+			const n = stream instanceof PDFRawStream ? stream.dict.lookup(PDFName.of("N")) : undefined;
+			const channels = n instanceof PDFNumber ? n.asNumber() : 0;
+			return channels === 1 || channels === 3;
+		}
+		return kind === "/CalRGB" || kind === "/CalGray";
+	}
+	return false;
+}
+
+// --- Placement analysis: work out each image's on-page size, hence its DPI ---
+// A crop of a mini PDF content-stream interpreter: it tracks the CTM through
+// q/Q/cm and follows Do into image and form XObjects. Resource name → object
+// ref comes straight from each page/form's /XObject dict, so no fuzzy matching
+// is needed. Anything it can't parse is simply skipped (→ quality-only).
+
+type Matrix = [number, number, number, number, number, number];
+type Token = { t: "num"; v: number } | { t: "name"; v: string } | { t: "op"; v: string };
+
+const IDENTITY: Matrix = [1, 0, 0, 1, 0, 0];
+
+// Row-vector affine multiply: apply `m` first, then `n`.
+function matmul(m: Matrix, n: Matrix): Matrix {
+	return [
+		m[0] * n[0] + m[1] * n[2],
+		m[0] * n[1] + m[1] * n[3],
+		m[2] * n[0] + m[3] * n[2],
+		m[2] * n[1] + m[3] * n[3],
+		m[4] * n[0] + m[5] * n[2] + n[4],
+		m[4] * n[1] + m[5] * n[3] + n[5],
+	];
+}
+
+function decodeName(raw: string) {
+	return raw.replace(/#([0-9A-F]{2})/gi, (_, hex) => String.fromCharCode(Number.parseInt(hex, 16)));
+}
+
+async function inflate(bytes: Uint8Array): Promise<Uint8Array | null> {
+	if (typeof DecompressionStream === "undefined")
+		return null;
+	for (const format of ["deflate", "deflate-raw"] as const) {
+		try {
+			const stream = new Blob([bytes as BlobPart]).stream().pipeThrough(new DecompressionStream(format));
+			return new Uint8Array(await new Response(stream).arrayBuffer());
+		}
+		catch {
+			// Try the next format.
+		}
+	}
+	return null;
+}
+
+async function decodedStreamBytes(stream: PDFRawStream): Promise<Uint8Array | null> {
+	const dict = stream.dict;
+	const parms = dict.lookup(PDFName.of("DecodeParms")) ?? dict.lookup(PDFName.of("DP"));
+	if (parms instanceof PDFDict && parms.lookup(PDFName.of("Predictor")))
+		return null;
+	const filter = dict.lookup(PDFName.of("Filter"));
+	if (!filter)
+		return stream.contents;
+	const isFlate = (filter instanceof PDFName && filter.toString() === "/FlateDecode")
+		|| (filter instanceof PDFArray && filter.size() === 1 && filter.lookup(0)?.toString() === "/FlateDecode");
+	return isFlate ? inflate(stream.contents) : null;
+}
+
+function readMatrix(dict: PDFDict): Matrix {
+	const m = dict.lookup(PDFName.of("Matrix"));
+	if (m instanceof PDFArray && m.size() === 6) {
+		const out = IDENTITY.slice() as Matrix;
+		for (let k = 0; k < 6; k += 1) {
+			const value = m.lookup(k);
+			if (value instanceof PDFNumber)
+				out[k] = value.asNumber();
+		}
+		return out;
+	}
+	return IDENTITY.slice() as Matrix;
+}
+
+function buildXObjectMap(resources: PDFDict): Map<string, PDFRef> {
+	const map = new Map<string, PDFRef>();
+	const xobject = resources.lookup(PDFName.of("XObject"));
+	if (!(xobject instanceof PDFDict))
+		return map;
+	for (const [name, value] of xobject.entries()) {
+		if (value instanceof PDFRef)
+			map.set(decodeName(name.toString().slice(1)), value);
+	}
+	return map;
+}
+
+function isWhitespace(c: number) {
+	return c === 0 || c === 9 || c === 10 || c === 12 || c === 13 || c === 32;
+}
+
+function isDelimiter(c: number) {
+	return c === 40 || c === 41 || c === 60 || c === 62 || c === 91 || c === 93 || c === 123 || c === 125 || c === 47 || c === 37;
+}
+
+function tokenizeContent(bytes: Uint8Array): Token[] {
+	const tokens: Token[] = [];
+	const n = bytes.length;
+	let i = 0;
+	while (i < n) {
+		const c = bytes[i];
+		if (isWhitespace(c) || c === 91 || c === 93) {
+			i += 1;
+		}
+		else if (c === 37) { // % comment
+			while (i < n && bytes[i] !== 10 && bytes[i] !== 13)
+				i += 1;
+		}
+		else if (c === 40) { // ( literal string
+			i += 1;
+			let depth = 1;
+			while (i < n && depth > 0) {
+				const d = bytes[i++];
+				if (d === 92)
+					i += 1;
+				else if (d === 40)
+					depth += 1;
+				else if (d === 41)
+					depth -= 1;
+			}
+		}
+		else if (c === 60 && bytes[i + 1] === 60) { // << dict
+			i += 2;
+			let depth = 1;
+			while (i < n && depth > 0) {
+				if (bytes[i] === 60 && bytes[i + 1] === 60) {
+					depth += 1;
+					i += 2;
+				}
+				else if (bytes[i] === 62 && bytes[i + 1] === 62) {
+					depth -= 1;
+					i += 2;
+				}
+				else if (bytes[i] === 40) {
+					i += 1;
+					let sd = 1;
+					while (i < n && sd > 0) {
+						const d = bytes[i++];
+						if (d === 92)
+							i += 1;
+						else if (d === 40)
+							sd += 1;
+						else if (d === 41)
+							sd -= 1;
+					}
+				}
+				else {
+					i += 1;
+				}
+			}
+		}
+		else if (c === 60) { // < hex string
+			i += 1;
+			while (i < n && bytes[i] !== 62)
+				i += 1;
+			i += 1;
+		}
+		else if (c === 47) { // /Name
+			i += 1;
+			let name = "";
+			while (i < n && !isWhitespace(bytes[i]) && !isDelimiter(bytes[i])) {
+				if (bytes[i] === 35 && i + 2 < n) {
+					const code = Number.parseInt(String.fromCharCode(bytes[i + 1], bytes[i + 2]), 16);
+					if (!Number.isNaN(code)) {
+						name += String.fromCharCode(code);
+						i += 3;
+						continue;
+					}
+				}
+				name += String.fromCharCode(bytes[i]);
+				i += 1;
+			}
+			tokens.push({ t: "name", v: name });
+		}
+		else if ((c >= 48 && c <= 57) || c === 43 || c === 45 || c === 46) { // number
+			let s = "";
+			while (i < n && !isWhitespace(bytes[i]) && !isDelimiter(bytes[i]))
+				s += String.fromCharCode(bytes[i++]);
+			const num = Number(s);
+			if (Number.isFinite(num))
+				tokens.push({ t: "num", v: num });
+		}
+		else { // operator keyword
+			let s = "";
+			while (i < n && !isWhitespace(bytes[i]) && !isDelimiter(bytes[i]))
+				s += String.fromCharCode(bytes[i++]);
+			if (s === "") {
+				i += 1;
+			}
+			else if (s === "BI") { // skip inline image up to EI
+				while (i < n) {
+					if (bytes[i] === 69 && bytes[i + 1] === 73 && (i === 0 || isWhitespace(bytes[i - 1])) && (i + 2 >= n || isWhitespace(bytes[i + 2]) || isDelimiter(bytes[i + 2]))) {
+						i += 2;
+						break;
+					}
+					i += 1;
+				}
+			}
+			else {
+				tokens.push({ t: "op", v: s });
+			}
+		}
+	}
+	return tokens;
+}
+
+interface Placement { w: number; h: number }
+
+async function recordPlacements(
+	doc: PDFDocument,
+	placements: Map<string, Placement>,
+	tokens: Token[],
+	xobjectMap: Map<string, PDFRef>,
+	baseCtm: Matrix,
+	depth: number,
+	visited: Set<string>,
+) {
+	let ctm = baseCtm;
+	const stack: Matrix[] = [];
+	let operands: number[] = [];
+	let lastName: string | null = null;
+
+	for (const token of tokens) {
+		if (token.t === "num") {
+			operands.push(token.v);
+			continue;
+		}
+		if (token.t === "name") {
+			lastName = token.v;
+			continue;
+		}
+		if (token.v === "q") {
+			stack.push(ctm);
+		}
+		else if (token.v === "Q") {
+			ctm = stack.pop() ?? ctm;
+		}
+		else if (token.v === "cm" && operands.length >= 6) {
+			ctm = matmul(operands.slice(-6) as Matrix, ctm);
+		}
+		else if (token.v === "Do" && lastName && xobjectMap.has(lastName)) {
+			const ref = xobjectMap.get(lastName)!;
+			const obj = doc.context.lookup(ref);
+			if (obj instanceof PDFRawStream) {
+				const subtype = obj.dict.lookup(PDFName.of("Subtype"))?.toString();
+				if (subtype === "/Image") {
+					const w = Math.hypot(ctm[0], ctm[1]);
+					const h = Math.hypot(ctm[2], ctm[3]);
+					const key = ref.toString();
+					const prev = placements.get(key);
+					if (!prev || w * h > prev.w * prev.h)
+						placements.set(key, { w, h });
+				}
+				else if (subtype === "/Form" && depth < 8 && !visited.has(ref.toString())) {
+					const formBytes = await decodedStreamBytes(obj);
+					if (formBytes) {
+						const resources = obj.dict.lookup(PDFName.of("Resources"));
+						const formMap = resources instanceof PDFDict ? buildXObjectMap(resources) : xobjectMap;
+						const nextVisited = new Set(visited).add(ref.toString());
+						await recordPlacements(doc, placements, tokenizeContent(formBytes), formMap, matmul(readMatrix(obj.dict), ctm), depth + 1, nextVisited);
+					}
+				}
+			}
+		}
+		operands = [];
+		lastName = null;
+	}
+}
+
+async function buildPlacementMap(doc: PDFDocument): Promise<Map<string, Placement>> {
+	const placements = new Map<string, Placement>();
+	if (typeof DecompressionStream === "undefined")
+		return placements;
+	for (const page of doc.getPages()) {
+		try {
+			const resources = page.node.Resources();
+			const xobjectMap = resources ? buildXObjectMap(resources) : new Map<string, PDFRef>();
+			if (xobjectMap.size === 0)
+				continue;
+			const contents = page.node.Contents();
+			const streams: PDFRawStream[] = [];
+			if (contents instanceof PDFArray) {
+				for (let k = 0; k < contents.size(); k += 1) {
+					const s = contents.lookup(k);
+					if (s instanceof PDFRawStream)
+						streams.push(s);
+				}
+			}
+			else if (contents instanceof PDFRawStream) {
+				streams.push(contents);
+			}
+			const parts: Uint8Array[] = [];
+			let ok = true;
+			for (const s of streams) {
+				const decoded = await decodedStreamBytes(s);
+				if (!decoded) {
+					ok = false;
+					break;
+				}
+				parts.push(decoded, new Uint8Array([32]));
+			}
+			if (!ok || parts.length === 0)
+				continue;
+			const total = parts.reduce((sum, p) => sum + p.length, 0);
+			const merged = new Uint8Array(total);
+			let offset = 0;
+			for (const p of parts) {
+				merged.set(p, offset);
+				offset += p.length;
+			}
+			await recordPlacements(doc, placements, tokenizeContent(merged), xobjectMap, IDENTITY, 0, new Set());
+		}
+		catch {
+			// Skip pages we can't analyse; their images fall back to quality-only.
+		}
+	}
+	return placements;
+}
+
+export async function downsamplePdf(bytes: ArrayBuffer, options: { imageDpi: number; imageQuality: number }): Promise<Uint8Array> {
+	const doc = await PDFDocument.load(bytes, { updateMetadata: false });
+	const qualityRatio = options.imageQuality / 100;
+	const placements = options.imageDpi > 0 ? await buildPlacementMap(doc) : new Map<string, Placement>();
+
+	for (const [ref, obj] of doc.context.enumerateIndirectObjects()) {
+		if (!(obj instanceof PDFRawStream))
+			continue;
+		try {
+			const dict = obj.dict;
+			if (dict.lookup(PDFName.of("Subtype"))?.toString() !== "/Image")
+				continue;
+			if (dict.get(PDFName.of("ImageMask")) || dict.get(PDFName.of("Decode")))
+				continue;
+			if (!isPlainJpeg(dict) || !colorSpaceSupported(dict))
+				continue;
+			if (numberVal(dict, "Width") <= 0 || numberVal(dict, "Height") <= 0)
+				continue;
+
+			const original = obj.contents;
+			let bitmap: ImageBitmap;
+			try {
+				bitmap = await createImageBitmap(new Blob([original as BlobPart], { type: "image/jpeg" }));
+			}
+			catch {
+				continue;
+			}
+
+			let scale = 1;
+			const place = placements.get(ref.toString());
+			if (options.imageDpi > 0 && place && place.w > 0 && place.h > 0) {
+				// DPI = pixels / (points / 72). Downscale so neither axis exceeds the target.
+				const dpiX = (bitmap.width * 72) / place.w;
+				const dpiY = (bitmap.height * 72) / place.h;
+				const fit = Math.min(options.imageDpi / dpiX, options.imageDpi / dpiY);
+				if (Number.isFinite(fit) && fit > 0 && fit < 1)
+					scale = fit;
+			}
+			const newW = Math.max(1, Math.round(bitmap.width * scale));
+			const newH = Math.max(1, Math.round(bitmap.height * scale));
+
+			const canvas = document.createElement("canvas");
+			canvas.width = newW;
+			canvas.height = newH;
+			const ctx = canvas.getContext("2d");
+			if (!ctx) {
+				bitmap.close();
+				continue;
+			}
+			ctx.drawImage(bitmap, 0, 0, newW, newH);
+			bitmap.close();
+
+			const outBlob = await canvasToBlob(canvas, "image/jpeg", qualityRatio);
+			const newBytes = new Uint8Array(await outBlob.arrayBuffer());
+			// Skip if we neither shrank dimensions nor saved bytes.
+			if (scale === 1 && newBytes.length >= original.length)
+				continue;
+
+			dict.set(PDFName.of("Width"), PDFNumber.of(newW));
+			dict.set(PDFName.of("Height"), PDFNumber.of(newH));
+			dict.set(PDFName.of("ColorSpace"), PDFName.of("DeviceRGB"));
+			dict.set(PDFName.of("BitsPerComponent"), PDFNumber.of(8));
+			dict.set(PDFName.of("Filter"), PDFName.of("DCTDecode"));
+			dict.delete(PDFName.of("DecodeParms"));
+			dict.set(PDFName.of("Length"), PDFNumber.of(newBytes.length));
+			doc.context.assign(ref, PDFRawStream.of(dict, newBytes));
+		}
+		catch {
+			// Leave any problematic image untouched.
+		}
+	}
+
+	doc.setTitle("");
+	doc.setAuthor("");
+	doc.setSubject("");
+	doc.setKeywords([]);
+	doc.setProducer("");
+	doc.setCreator("");
+	return doc.save({ useObjectStreams: true });
+}

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,5 +1,5 @@
 import type { Tool } from "$lib/types";
-import { Columns3, Files, Globe, Grid2x2, Images, LayoutGrid, QrCode, Shrink } from "@lucide/svelte";
+import { Columns3, Crop, FileArchive, Files, Globe, Grid2x2, Images, LayoutGrid, QrCode, Shrink } from "@lucide/svelte";
 
 export const tools: Tool[] = [
 	{
@@ -28,6 +28,20 @@ export const tools: Tool[] = [
 		description: "Compress, resize, and convert many images at once",
 		path: "/tools/image-compressor",
 		icon: Shrink,
+		status: "ready",
+	},
+	{
+		name: "Image Cropper",
+		description: "Crop images to an aspect ratio, with per-image fine-tuning",
+		path: "/tools/image-cropper",
+		icon: Crop,
+		status: "ready",
+	},
+	{
+		name: "PDF Compressor",
+		description: "Shrink PDFs by downsampling images or rasterizing pages",
+		path: "/tools/pdf-compressor",
+		icon: FileArchive,
 		status: "ready",
 	},
 	{

--- a/src/routes/tools/image-cropper/+page.svelte
+++ b/src/routes/tools/image-cropper/+page.svelte
@@ -1,0 +1,846 @@
+<script lang="ts">
+	import { resolve as resolvePath } from "$app/paths";
+	import { Button } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Checkbox } from "$lib/components/ui/checkbox";
+	import { Input } from "$lib/components/ui/input";
+	import { Label } from "$lib/components/ui/label";
+	import { Select } from "$lib/components/ui/select";
+	import { Slider } from "$lib/components/ui/slider";
+	import { cn } from "$lib/utils";
+	import { ChevronLeft, ChevronRight, Crop, LoaderCircle, Package, Pencil, RotateCcw, Upload, X } from "@lucide/svelte";
+	import JSZip from "jszip";
+	import { onDestroy } from "svelte";
+
+	type OutputFormat = "jpeg" | "png" | "webp";
+	type CropRect = { x: number; y: number; w: number; h: number };
+
+	type SourceImage = {
+		id: string;
+		file: File;
+		previewUrl: string;
+		naturalWidth: number;
+		naturalHeight: number;
+		crop: CropRect;
+		customized: boolean;
+	};
+
+	type ProcessedImage = {
+		fileName: string;
+		blob: Blob;
+		previewUrl: string;
+		width: number;
+		height: number;
+	};
+
+	const formatOptions: Array<{ value: OutputFormat; label: string; mime: string; extension: string }> = [
+		{ value: "jpeg", label: "JPEG", mime: "image/jpeg", extension: "jpg" },
+		{ value: "png", label: "PNG", mime: "image/png", extension: "png" },
+		{ value: "webp", label: "WebP", mime: "image/webp", extension: "webp" },
+	];
+
+	const ratioOptions: Array<{ label: string; value: string; ratio: number | null }> = [
+		{ label: "Free", value: "free", ratio: null },
+		{ label: "1:1", value: "1:1", ratio: 1 },
+		{ label: "4:5", value: "4:5", ratio: 4 / 5 },
+		{ label: "5:4", value: "5:4", ratio: 5 / 4 },
+		{ label: "3:4", value: "3:4", ratio: 3 / 4 },
+		{ label: "4:3", value: "4:3", ratio: 4 / 3 },
+		{ label: "2:3", value: "2:3", ratio: 2 / 3 },
+		{ label: "3:2", value: "3:2", ratio: 3 / 2 },
+		{ label: "9:16", value: "9:16", ratio: 9 / 16 },
+		{ label: "16:9", value: "16:9", ratio: 16 / 9 },
+		{ label: "Custom", value: "custom", ratio: null },
+	];
+
+	const alignSteps = [0, 0.5, 1];
+	const FILE_EXTENSION_RE = /\.[^.]+$/;
+	const MIN_CROP_PX = 16;
+
+	let sourceImages = $state<SourceImage[]>([]);
+	let processedImages = $state<ProcessedImage[]>([]);
+	let error = $state("");
+	let processing = $state(false);
+	let processedCount = $state(0);
+
+	let ratioValue = $state("1:1");
+	let customW = $state(1);
+	let customH = $state(1);
+	let alignX = $state(0.5);
+	let alignY = $state(0.5);
+	let useExactSize = $state(false);
+	let outW = $state(1080);
+	let outH = $state(1080);
+	let outputFormat = $state<OutputFormat>("jpeg");
+	let quality = $state(90);
+
+	let editingId = $state<string | null>(null);
+	let editorDispW = $state(0);
+	let editorDispH = $state(0);
+
+	const activeFormat = $derived(formatOptions.find(option => option.value === outputFormat) ?? formatOptions[0]);
+	const hasResults = $derived(processedImages.length > 0);
+	const canProcess = $derived(sourceImages.length > 0 && !processing);
+	const editingIndex = $derived(sourceImages.findIndex(item => item.id === editingId));
+	const editingImage = $derived(editingIndex >= 0 ? sourceImages[editingIndex] : null);
+
+	const activeRatio = $derived.by(() => {
+		if (useExactSize) {
+			const r = outW / outH;
+			return Number.isFinite(r) && r > 0 ? r : null;
+		}
+		if (ratioValue === "custom") {
+			const r = customW / customH;
+			return Number.isFinite(r) && r > 0 ? r : null;
+		}
+		return ratioOptions.find(option => option.value === ratioValue)?.ratio ?? null;
+	});
+
+	function formatBytes(bytes: number) {
+		if (!Number.isFinite(bytes) || bytes <= 0)
+			return "0 B";
+		const units = ["B", "KB", "MB", "GB"];
+		let value = bytes;
+		let index = 0;
+		while (value >= 1024 && index < units.length - 1) {
+			value /= 1024;
+			index += 1;
+		}
+		return `${value.toFixed(value >= 100 || index === 0 ? 0 : 1)} ${units[index]}`;
+	}
+
+	function baseName(fileName: string) {
+		return fileName.replace(FILE_EXTENSION_RE, "");
+	}
+
+	function sanitizeQuality(value: number, fallback: number) {
+		if (!Number.isFinite(value))
+			return fallback;
+		return Math.min(100, Math.max(1, Math.floor(value)));
+	}
+
+	function defaultCrop(natW: number, natH: number, ratio: number | null, ax: number, ay: number): CropRect {
+		if (ratio === null)
+			return { x: 0, y: 0, w: natW, h: natH };
+		const imageRatio = natW / natH;
+		let w: number;
+		let h: number;
+		if (imageRatio > ratio) {
+			h = natH;
+			w = h * ratio;
+		}
+		else {
+			w = natW;
+			h = w / ratio;
+		}
+		w = Math.round(w);
+		h = Math.round(h);
+		return {
+			x: Math.round((natW - w) * ax),
+			y: Math.round((natH - h) * ay),
+			w,
+			h,
+		};
+	}
+
+	function nearestAlign(pos: number, total: number, size: number) {
+		if (total - size <= 0)
+			return 0.5;
+		const fraction = pos / (total - size);
+		return fraction < 0.25 ? 0 : fraction > 0.75 ? 1 : 0.5;
+	}
+
+	async function loadImage(src: string): Promise<HTMLImageElement> {
+		return new Promise((resolve, reject) => {
+			const img = new Image();
+			img.onload = () => resolve(img);
+			img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+			img.src = src;
+		});
+	}
+
+	function clearProcessedImages() {
+		processedImages.forEach(item => URL.revokeObjectURL(item.previewUrl));
+		processedImages = [];
+	}
+
+	function clearSourceImages() {
+		sourceImages.forEach(item => URL.revokeObjectURL(item.previewUrl));
+		sourceImages = [];
+	}
+
+	function clearAll() {
+		clearSourceImages();
+		clearProcessedImages();
+		editingId = null;
+		error = "";
+		processedCount = 0;
+	}
+
+	onDestroy(() => {
+		clearSourceImages();
+		clearProcessedImages();
+	});
+
+	function handleDragOver(event: DragEvent) {
+		event.preventDefault();
+	}
+
+	async function filesToSourceImages(files: File[]) {
+		const validFiles = files.filter(file => file.type.startsWith("image/"));
+		if (validFiles.length === 0) {
+			error = "Please select one or more image files";
+			return;
+		}
+
+		error = "";
+		clearProcessedImages();
+
+		const loaded: SourceImage[] = [];
+		for (const file of validFiles) {
+			const previewUrl = URL.createObjectURL(file);
+			try {
+				const img = await loadImage(previewUrl);
+				loaded.push({
+					id: `img-${crypto.randomUUID()}`,
+					file,
+					previewUrl,
+					naturalWidth: img.naturalWidth,
+					naturalHeight: img.naturalHeight,
+					crop: defaultCrop(img.naturalWidth, img.naturalHeight, activeRatio, alignX, alignY),
+					customized: false,
+				});
+			}
+			catch {
+				URL.revokeObjectURL(previewUrl);
+			}
+		}
+
+		clearSourceImages();
+		sourceImages = loaded;
+		processedCount = 0;
+		if (loaded.length === 0)
+			error = "Could not load selected images";
+	}
+
+	async function handleSelect(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const files = input.files ? [...input.files] : [];
+		await filesToSourceImages(files);
+		input.value = "";
+	}
+
+	async function handleDrop(event: DragEvent) {
+		event.preventDefault();
+		const files = event.dataTransfer?.files ? [...event.dataTransfer.files] : [];
+		await filesToSourceImages(files);
+	}
+
+	// Re-apply the default crop (ratio + alignment) to every image. Manual per-image
+	// tweaks are intentionally reset so the shared settings stay predictable.
+	function applyRatioToAll() {
+		clearProcessedImages();
+		for (const item of sourceImages) {
+			item.crop = defaultCrop(item.naturalWidth, item.naturalHeight, activeRatio, alignX, alignY);
+			item.customized = false;
+		}
+	}
+
+	function selectRatio(value: string) {
+		ratioValue = value;
+		if (value !== "custom")
+			applyRatioToAll();
+	}
+
+	function applyCustomRatio() {
+		if (ratioValue === "custom")
+			applyRatioToAll();
+	}
+
+	function setAlignment(ax: number, ay: number) {
+		alignX = ax;
+		alignY = ay;
+		applyRatioToAll();
+	}
+
+	function toggleExactSize(checked: boolean) {
+		useExactSize = checked;
+		applyRatioToAll();
+	}
+
+	function applyExactSize() {
+		if (useExactSize)
+			applyRatioToAll();
+	}
+
+	function resetCrop(id: string) {
+		const item = sourceImages.find(entry => entry.id === id);
+		if (!item)
+			return;
+		item.crop = defaultCrop(item.naturalWidth, item.naturalHeight, activeRatio, alignX, alignY);
+		item.customized = false;
+		clearProcessedImages();
+	}
+
+	// --- Interactive crop editor -------------------------------------------------
+
+	type DragMode = "move" | "nw" | "ne" | "sw" | "se";
+	let drag: { mode: DragMode; startX: number; startY: number; rect: CropRect } | null = null;
+
+	function openEditor(id: string) {
+		editingId = id;
+	}
+
+	function openFirstEditor() {
+		if (sourceImages.length > 0)
+			editingId = sourceImages[0].id;
+	}
+
+	function closeEditor() {
+		editingId = null;
+	}
+
+	function gotoDelta(delta: number) {
+		if (editingIndex < 0)
+			return;
+		const next = editingIndex + delta;
+		if (next < 0 || next >= sourceImages.length)
+			return;
+		editingId = sourceImages[next].id;
+	}
+
+	$effect(() => {
+		if (!editingId)
+			return;
+		function onKey(event: KeyboardEvent) {
+			if (event.key === "Escape")
+				closeEditor();
+			else if (event.key === "ArrowLeft")
+				gotoDelta(-1);
+			else if (event.key === "ArrowRight")
+				gotoDelta(1);
+		}
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	});
+
+	// Reposition the current image's crop to an alignment anchor, keeping its size.
+	function alignCurrentCrop(ax: number, ay: number) {
+		const item = editingImage;
+		if (!item)
+			return;
+		item.crop = {
+			...item.crop,
+			x: Math.round((item.naturalWidth - item.crop.w) * ax),
+			y: Math.round((item.naturalHeight - item.crop.h) * ay),
+		};
+		item.customized = true;
+		clearProcessedImages();
+	}
+
+	function startDrag(mode: DragMode, event: PointerEvent) {
+		if (!editingImage)
+			return;
+		event.preventDefault();
+		// Stop a handle's pointerdown from bubbling to the box's "move" handler,
+		// which would otherwise overwrite the resize with a move.
+		event.stopPropagation();
+		drag = { mode, startX: event.clientX, startY: event.clientY, rect: { ...editingImage.crop } };
+		window.addEventListener("pointermove", onDrag);
+		window.addEventListener("pointerup", endDrag);
+	}
+
+	function clamp(value: number, min: number, max: number) {
+		return Math.min(max, Math.max(min, value));
+	}
+
+	function onDrag(event: PointerEvent) {
+		const item = editingImage;
+		if (!drag || !item || editorDispW <= 0)
+			return;
+		const scale = item.naturalWidth / editorDispW;
+		const dx = (event.clientX - drag.startX) * scale;
+		const dy = (event.clientY - drag.startY) * scale;
+		const start = drag.rect;
+		const natW = item.naturalWidth;
+		const natH = item.naturalHeight;
+
+		if (drag.mode === "move") {
+			item.crop = {
+				...start,
+				x: clamp(start.x + dx, 0, natW - start.w),
+				y: clamp(start.y + dy, 0, natH - start.h),
+			};
+			item.customized = true;
+			return;
+		}
+
+		// Corner resize: opposite corner stays fixed.
+		const dirX = drag.mode === "ne" || drag.mode === "se" ? 1 : -1;
+		const dirY = drag.mode === "sw" || drag.mode === "se" ? 1 : -1;
+		const fixedX = dirX > 0 ? start.x : start.x + start.w;
+		const fixedY = dirY > 0 ? start.y : start.y + start.h;
+		const pointerX = (dirX > 0 ? start.x + start.w : start.x) + dx;
+		const pointerY = (dirY > 0 ? start.y + start.h : start.y) + dy;
+
+		const availW = dirX > 0 ? natW - fixedX : fixedX;
+		const availH = dirY > 0 ? natH - fixedY : fixedY;
+
+		let w: number;
+		let h: number;
+		if (activeRatio !== null) {
+			w = clamp(Math.abs(pointerX - fixedX), MIN_CROP_PX, availW);
+			h = w / activeRatio;
+			if (h > availH) {
+				h = availH;
+				w = h * activeRatio;
+			}
+			w = Math.max(w, MIN_CROP_PX);
+			h = Math.max(h, MIN_CROP_PX);
+		}
+		else {
+			w = clamp(Math.abs(pointerX - fixedX), MIN_CROP_PX, availW);
+			h = clamp(Math.abs(pointerY - fixedY), MIN_CROP_PX, availH);
+		}
+
+		item.crop = {
+			x: Math.round(dirX > 0 ? fixedX : fixedX - w),
+			y: Math.round(dirY > 0 ? fixedY : fixedY - h),
+			w: Math.round(w),
+			h: Math.round(h),
+		};
+		item.customized = true;
+	}
+
+	function endDrag() {
+		drag = null;
+		window.removeEventListener("pointermove", onDrag);
+		window.removeEventListener("pointerup", endDrag);
+		clearProcessedImages();
+	}
+
+	async function canvasToBlob(canvas: HTMLCanvasElement, mime: string, qualityValue?: number): Promise<Blob> {
+		return new Promise((resolve, reject) => {
+			canvas.toBlob((blob) => {
+				if (!blob) {
+					reject(new Error("Failed to encode image"));
+					return;
+				}
+				resolve(blob);
+			}, mime, qualityValue);
+		});
+	}
+
+	async function processImages() {
+		if (sourceImages.length === 0)
+			return;
+
+		quality = sanitizeQuality(quality, 90);
+		processing = true;
+		processedCount = 0;
+		error = "";
+		clearProcessedImages();
+
+		try {
+			const next: ProcessedImage[] = [];
+			const qualityRatio = quality / 100;
+			const exactW = Math.max(1, Math.round(outW));
+			const exactH = Math.max(1, Math.round(outH));
+
+			for (let index = 0; index < sourceImages.length; index += 1) {
+				const source = sourceImages[index];
+				const img = await loadImage(source.previewUrl);
+				const crop = source.crop;
+				const cropW = Math.max(1, Math.round(crop.w));
+				const cropH = Math.max(1, Math.round(crop.h));
+				const targetW = useExactSize ? exactW : cropW;
+				const targetH = useExactSize ? exactH : cropH;
+				const canvas = document.createElement("canvas");
+				canvas.width = targetW;
+				canvas.height = targetH;
+				const ctx = canvas.getContext("2d");
+				if (!ctx)
+					throw new Error("Unable to create canvas context");
+				ctx.drawImage(img, crop.x, crop.y, cropW, cropH, 0, 0, targetW, targetH);
+
+				const blob = await canvasToBlob(
+					canvas,
+					activeFormat.mime,
+					outputFormat === "png" ? undefined : qualityRatio,
+				);
+				const previewUrl = URL.createObjectURL(blob);
+				next.push({
+					fileName: `${baseName(source.file.name)}_cropped.${activeFormat.extension}`,
+					blob,
+					previewUrl,
+					width: targetW,
+					height: targetH,
+				});
+				processedCount = index + 1;
+			}
+
+			processedImages = next;
+		}
+		catch (err) {
+			error = (err as Error).message || "Failed to process images";
+			clearProcessedImages();
+		}
+		finally {
+			processing = false;
+		}
+	}
+
+	function downloadBlob(blob: Blob, name: string) {
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = name;
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
+	}
+
+	async function downloadZip() {
+		if (processedImages.length === 0 || processing)
+			return;
+		processing = true;
+		error = "";
+		try {
+			const zip = new JSZip();
+			processedImages.forEach((item) => {
+				zip.file(item.fileName, item.blob);
+			});
+			const blob = await zip.generateAsync({ type: "blob" });
+			downloadBlob(blob, `cropped_images_${outputFormat}.zip`);
+		}
+		catch (err) {
+			error = (err as Error).message || "Failed to create zip";
+		}
+		finally {
+			processing = false;
+		}
+	}
+</script>
+
+{#snippet alignGrid(currentX: number, currentY: number, pick: (x: number, y: number) => void, disabled: boolean)}
+	<div class="bg-muted grid w-fit grid-cols-3 gap-1 rounded-lg p-1" role="group" aria-label="Crop alignment">
+		{#each alignSteps as ay (ay)}
+			{#each alignSteps as ax (ax)}
+				<button
+					type="button"
+					{disabled}
+					class={cn(
+						"flex size-7 items-center justify-center rounded transition-colors disabled:opacity-40",
+						currentX === ax && currentY === ay ? "bg-primary text-primary-foreground" : "hover:bg-accent text-muted-foreground",
+					)}
+					onclick={() => pick(ax, ay)}
+					aria-label="Align {ay === 0 ? "top" : ay === 1 ? "bottom" : "middle"} {ax === 0 ? "left" : ax === 1 ? "right" : "centre"}"
+					aria-pressed={currentX === ax && currentY === ay}
+				>
+					<span class="size-1.5 rounded-full bg-current"></span>
+				</button>
+			{/each}
+		{/each}
+	</div>
+{/snippet}
+
+<svelte:head>
+	<title>Image Cropper</title>
+</svelte:head>
+
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
+
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight">
+		<Crop class="text-primary size-7" />
+		Image Cropper
+	</h1>
+	<p class="text-muted-foreground mb-8">Crop many images to a shared aspect ratio, then fine-tune any of them individually.</p>
+
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Upload Images</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<label
+				class="border-input hover:border-ring hover:bg-accent bg-muted/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
+				ondrop={handleDrop}
+				ondragover={handleDragOver}
+			>
+				<Upload class="text-muted-foreground size-9" />
+				<p class="font-medium">Drag & drop image files</p>
+				<p class="text-muted-foreground text-sm">or click to browse</p>
+				{#if sourceImages.length > 0}
+					<p class="text-muted-foreground text-sm">{sourceImages.length} image{sourceImages.length === 1 ? "" : "s"} loaded</p>
+				{/if}
+				<input type="file" accept="image/*" multiple onchange={handleSelect} hidden />
+			</label>
+			{#if sourceImages.length > 0}
+				<div class="mt-3">
+					<Button variant="outline" size="sm" onclick={clearAll}>Clear All</Button>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Crop Settings</Card.Title>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="grid gap-1.5">
+				<Label>Aspect Ratio</Label>
+				<div class="bg-muted inline-flex flex-wrap gap-1 rounded-lg p-1">
+					{#each ratioOptions as option (option.value)}
+						<Button variant={!useExactSize && ratioValue === option.value ? "default" : "ghost"} size="sm" disabled={useExactSize} onclick={() => selectRatio(option.value)}>{option.label}</Button>
+					{/each}
+				</div>
+				{#if useExactSize}
+					<p class="text-muted-foreground text-xs">Exact output size is controlling the ratio ({outW}:{outH}).</p>
+				{/if}
+			</div>
+
+			{#if ratioValue === "custom" && !useExactSize}
+				<div class="flex flex-wrap items-end gap-3">
+					<div class="grid gap-1.5">
+						<Label for="customW">Width ratio</Label>
+						<Input id="customW" type="number" min={1} class="w-24" bind:value={customW} onchange={applyCustomRatio} />
+					</div>
+					<span class="pb-2 text-lg">:</span>
+					<div class="grid gap-1.5">
+						<Label for="customH">Height ratio</Label>
+						<Input id="customH" type="number" min={1} class="w-24" bind:value={customH} onchange={applyCustomRatio} />
+					</div>
+				</div>
+			{/if}
+
+			<div class="flex flex-wrap items-start gap-6">
+				<div class="grid gap-1.5">
+					<Label>Crop Alignment</Label>
+					{@render alignGrid(alignX, alignY, setAlignment, activeRatio === null)}
+					<p class="text-muted-foreground text-xs">{activeRatio === null ? "Only applies with a fixed ratio" : "Where the crop sits by default"}</p>
+				</div>
+
+				<div class="grid gap-1.5">
+					<Label>Output Size</Label>
+					<Label class="font-normal"><Checkbox checked={useExactSize} onCheckedChange={toggleExactSize} /> Resize to exact pixels</Label>
+					{#if useExactSize}
+						<div class="flex items-end gap-2">
+							<Input type="number" min={1} class="w-24" bind:value={outW} onchange={applyExactSize} aria-label="Output width" />
+							<span class="pb-2">×</span>
+							<Input type="number" min={1} class="w-24" bind:value={outH} onchange={applyExactSize} aria-label="Output height" />
+							<span class="text-muted-foreground pb-2 text-sm">px</span>
+						</div>
+					{/if}
+				</div>
+			</div>
+
+			<div class="grid grid-cols-2 gap-3">
+				<div class="grid gap-1.5">
+					<Label for="format">Output Format</Label>
+					<Select id="format" bind:value={outputFormat}>
+						{#each formatOptions as option (option.value)}
+							<option value={option.value}>{option.label}</option>
+						{/each}
+					</Select>
+				</div>
+				{#if outputFormat !== "png"}
+					<div class="grid gap-1.5">
+						<Label for="quality">Quality ({quality}%)</Label>
+						<div class="flex h-9 items-center"><Slider type="single" min={1} max={100} bind:value={quality} /></div>
+					</div>
+				{/if}
+			</div>
+			<p class="text-muted-foreground text-sm">
+				{#if activeRatio === null}
+					Free mode selects the whole image by default — open any image to draw a custom crop.
+				{:else}
+					Every image is cropped to this ratio. Open an image to reposition or resize its crop.
+				{/if}
+			</p>
+		</Card.Content>
+	</Card.Root>
+
+	{#if error}
+		<div class="border-destructive/40 bg-destructive/10 text-destructive mb-4 rounded-lg border px-4 py-3 text-sm">⚠️ {error}</div>
+	{/if}
+
+	{#if sourceImages.length > 0}
+		<div class="mb-6 flex flex-wrap items-center justify-center gap-3">
+			<Button variant="outline" size="lg" onclick={openFirstEditor} disabled={processing}>
+				<Pencil class="size-4" />
+				Customise Crop Positions
+			</Button>
+			<Button size="lg" onclick={processImages} disabled={!canProcess}>
+				{#if processing}
+					<LoaderCircle class="size-4 animate-spin" />
+					Cropping {processedCount}/{sourceImages.length}...
+				{:else}
+					Crop {sourceImages.length} Image{sourceImages.length === 1 ? "" : "s"}
+				{/if}
+			</Button>
+		</div>
+	{/if}
+
+	{#if sourceImages.length > 0}
+		<Card.Root class="mb-6">
+			<Card.Header>
+				<Card.Title>Images</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-3">
+					{#each sourceImages as item (item.id)}
+						{@const left = (item.crop.x / item.naturalWidth) * 100}
+						{@const top = (item.crop.y / item.naturalHeight) * 100}
+						{@const width = (item.crop.w / item.naturalWidth) * 100}
+						{@const height = (item.crop.h / item.naturalHeight) * 100}
+						<div class="overflow-hidden rounded-md border">
+							<button type="button" class="relative block w-full cursor-pointer" onclick={() => openEditor(item.id)} aria-label="Edit crop for {item.file.name}">
+								<img src={item.previewUrl} alt={item.file.name} loading="lazy" class="block max-h-40 w-full bg-black/5 object-contain" />
+								<span class="pointer-events-none absolute border-2 border-white shadow-[0_0_0_9999px_rgba(0,0,0,0.45)]" style="left:{left}%;top:{top}%;width:{width}%;height:{height}%;"></span>
+								{#if item.customized}
+									<span class="bg-primary text-primary-foreground absolute top-1 left-1 rounded px-1.5 py-0.5 text-[10px] font-medium">Custom</span>
+								{/if}
+							</button>
+							<div class="flex items-center justify-between gap-1 p-2">
+								<span class="text-muted-foreground truncate text-xs" title={item.file.name}>{item.file.name}</span>
+								<div class="flex shrink-0 gap-1">
+									<Button variant="ghost" size="icon" class="size-7" onclick={() => openEditor(item.id)} aria-label="Edit crop">
+										<Pencil class="size-3.5" />
+									</Button>
+									{#if item.customized}
+										<Button variant="ghost" size="icon" class="size-7" onclick={() => resetCrop(item.id)} aria-label="Reset crop">
+											<RotateCcw class="size-3.5" />
+										</Button>
+									{/if}
+								</div>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+
+	{#if hasResults}
+		<Card.Root class="mb-6" id="results">
+			<Card.Header class="flex-row items-center justify-between space-y-0">
+				<Card.Title>Results</Card.Title>
+				<Button onclick={downloadZip} disabled={processing}>
+					<Package class="size-4" />
+					Download ZIP
+				</Button>
+			</Card.Header>
+			<Card.Content>
+				<div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-3">
+					{#each processedImages as item (item.previewUrl)}
+						<div class="overflow-hidden rounded-md border">
+							<img src={item.previewUrl} alt={item.fileName} loading="lazy" class="block max-h-40 w-full bg-black/5 object-contain" />
+							<div class="text-muted-foreground flex flex-col gap-0.5 p-2 text-xs">
+								<span>{item.width} × {item.height}px</span>
+								<span>{formatBytes(item.blob.size)}</span>
+								<button type="button" class="text-primary text-left hover:underline" onclick={() => downloadBlob(item.blob, item.fileName)}>Download</button>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+
+	<footer class="text-muted-foreground text-center text-sm">
+		<p>✨ Runs in your browser • No uploads required</p>
+	</footer>
+</main>
+
+{#if editingImage}
+	{@const item = editingImage}
+	{@const scale = editorDispW > 0 ? editorDispW / item.naturalWidth : 0}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+		role="button"
+		tabindex="-1"
+		onclick={event => event.target === event.currentTarget && closeEditor()}
+		onkeydown={event => event.key === "Escape" && closeEditor()}
+	>
+		<div class="bg-background flex max-h-[90vh] w-full max-w-2xl flex-col gap-4 overflow-auto rounded-xl border p-4 shadow-xl">
+			<div class="flex items-center justify-between gap-2">
+				<h2 class="flex items-center gap-2 font-semibold"><Crop class="text-primary size-5" /> Adjust Crop</h2>
+				<div class="flex items-center gap-1">
+					<Button variant="outline" size="icon" class="size-8" onclick={() => gotoDelta(-1)} disabled={editingIndex <= 0} aria-label="Previous image">
+						<ChevronLeft class="size-4" />
+					</Button>
+					<span class="text-muted-foreground min-w-16 text-center text-sm tabular-nums">{editingIndex + 1} / {sourceImages.length}</span>
+					<Button variant="outline" size="icon" class="size-8" onclick={() => gotoDelta(1)} disabled={editingIndex >= sourceImages.length - 1} aria-label="Next image">
+						<ChevronRight class="size-4" />
+					</Button>
+					<Button variant="ghost" size="icon" class="size-8" onclick={closeEditor} aria-label="Close">
+						<X class="size-4" />
+					</Button>
+				</div>
+			</div>
+
+			<div class="flex justify-center">
+				<div class="relative inline-block touch-none select-none">
+					<img
+						src={item.previewUrl}
+						alt={item.file.name}
+						class="block max-h-[60vh] max-w-full"
+						bind:clientWidth={editorDispW}
+						bind:clientHeight={editorDispH}
+						draggable="false"
+					/>
+					{#if scale > 0}
+						{@const box = { left: item.crop.x * scale, top: item.crop.y * scale, w: item.crop.w * scale, h: item.crop.h * scale }}
+						<div class="pointer-events-none absolute inset-0 bg-black/50" style="clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 0, {box.left}px {box.top}px, {box.left}px {box.top + box.h}px, {box.left + box.w}px {box.top + box.h}px, {box.left + box.w}px {box.top}px, {box.left}px {box.top}px);"></div>
+						<div
+							class="absolute cursor-move border-2 border-white"
+							style="left:{box.left}px;top:{box.top}px;width:{box.w}px;height:{box.h}px;"
+							onpointerdown={event => startDrag("move", event)}
+							role="button"
+							tabindex="-1"
+							aria-label="Move crop"
+						>
+							{#each ["nw", "ne", "sw", "se"] as const as handle (handle)}
+								<span
+									class="border-primary absolute size-3 rounded-full border-2 bg-white"
+									class:cursor-nwse-resize={handle === "nw" || handle === "se"}
+									class:cursor-nesw-resize={handle === "ne" || handle === "sw"}
+									style="{handle.includes("n") ? "top:-6px" : "bottom:-6px"};{handle.includes("w") ? "left:-6px" : "right:-6px"};"
+									onpointerdown={event => startDrag(handle, event)}
+									role="button"
+									tabindex="-1"
+									aria-label="Resize crop {handle}"
+								></span>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			</div>
+
+			<div class="flex flex-wrap items-end justify-between gap-3">
+				<div class="grid gap-1.5">
+					<Label>Alignment</Label>
+					{@render alignGrid(
+						nearestAlign(item.crop.x, item.naturalWidth, item.crop.w),
+						nearestAlign(item.crop.y, item.naturalHeight, item.crop.h),
+						alignCurrentCrop,
+						false,
+					)}
+				</div>
+				<div class="text-muted-foreground flex flex-col items-end gap-2 text-sm">
+					<span>Crop: {Math.round(item.crop.w)} × {Math.round(item.crop.h)}px{activeRatio === null ? "" : useExactSize ? ` → ${Math.round(outW)} × ${Math.round(outH)}px` : ""}</span>
+					<div class="flex gap-2">
+						<Button variant="outline" size="sm" onclick={() => resetCrop(item.id)}>
+							<RotateCcw class="size-3.5" />
+							Reset
+						</Button>
+						<Button size="sm" onclick={closeEditor}>Done</Button>
+					</div>
+				</div>
+			</div>
+			<p class="text-muted-foreground text-center text-xs">Use ← → arrow keys to move between images</p>
+		</div>
+	</div>
+{/if}

--- a/src/routes/tools/pdf-compressor/+page.svelte
+++ b/src/routes/tools/pdf-compressor/+page.svelte
@@ -1,0 +1,382 @@
+<script lang="ts">
+	import { resolve as resolvePath } from "$app/paths";
+	import { Button } from "$lib/components/ui/button";
+	import * as Card from "$lib/components/ui/card";
+	import { Label } from "$lib/components/ui/label";
+	import { Select } from "$lib/components/ui/select";
+	import { Slider } from "$lib/components/ui/slider";
+	import { downsamplePdf, rasterizePdf } from "$lib/pdf-compress";
+	import { cn } from "$lib/utils";
+	import { FileArchive, LoaderCircle, Package, Trash2, Upload } from "@lucide/svelte";
+	import JSZip from "jszip";
+	import { onDestroy } from "svelte";
+
+	type CompressMode = "downsample" | "rasterize";
+
+	type SourcePdf = {
+		id: string;
+		file: File;
+	};
+
+	type ProcessedPdf = {
+		fileName: string;
+		blob: Blob;
+		originalSize: number;
+	};
+
+	const PDF_EXTENSION_RE = /\.pdf$/i;
+
+	const dpiOptions = [
+		{ value: 72, label: "72 (screen, smallest)" },
+		{ value: 96, label: "96 (screen)" },
+		{ value: 120, label: "120 (balanced)" },
+		{ value: 150, label: "150 (print)" },
+		{ value: 200, label: "200 (high quality)" },
+	];
+
+	const imageDpiOptions = [
+		{ value: 0, label: "Keep resolution (quality only)" },
+		{ value: 72, label: "72 DPI (screen, smallest)" },
+		{ value: 96, label: "96 DPI (screen)" },
+		{ value: 150, label: "150 DPI (balanced)" },
+		{ value: 200, label: "200 DPI (good print)" },
+		{ value: 300, label: "300 DPI (high quality)" },
+	];
+
+	let sourcePdfs = $state<SourcePdf[]>([]);
+	let processedPdfs = $state<ProcessedPdf[]>([]);
+	let error = $state("");
+	let processing = $state(false);
+	let processedCount = $state(0);
+	let statusText = $state("");
+
+	let mode = $state<CompressMode>("downsample");
+	let dpi = $state(96);
+	let quality = $state(65);
+	let imageDpi = $state(150);
+	let imageQuality = $state(65);
+
+	const hasResults = $derived(processedPdfs.length > 0);
+	const canProcess = $derived(sourcePdfs.length > 0 && !processing);
+	const originalTotalBytes = $derived(sourcePdfs.reduce((sum, item) => sum + item.file.size, 0));
+	const processedTotalBytes = $derived(processedPdfs.reduce((sum, item) => sum + item.blob.size, 0));
+	const sizeDeltaPercent = $derived(
+		originalTotalBytes > 0 && hasResults
+			? ((processedTotalBytes - originalTotalBytes) / originalTotalBytes) * 100
+			: 0,
+	);
+
+	function formatBytes(bytes: number) {
+		if (!Number.isFinite(bytes) || bytes <= 0)
+			return "0 B";
+		const units = ["B", "KB", "MB", "GB"];
+		let value = bytes;
+		let index = 0;
+		while (value >= 1024 && index < units.length - 1) {
+			value /= 1024;
+			index += 1;
+		}
+		return `${value.toFixed(value >= 100 || index === 0 ? 0 : 1)} ${units[index]}`;
+	}
+
+	function baseName(fileName: string) {
+		return fileName.replace(PDF_EXTENSION_RE, "");
+	}
+
+	function clearProcessed() {
+		processedPdfs = [];
+	}
+
+	function clearAll() {
+		sourcePdfs = [];
+		clearProcessed();
+		error = "";
+		statusText = "";
+		processedCount = 0;
+	}
+
+	onDestroy(() => {
+		clearProcessed();
+	});
+
+	function handleDragOver(event: DragEvent) {
+		event.preventDefault();
+	}
+
+	function addFiles(files: File[]) {
+		const valid = files.filter(file => file.type === "application/pdf" || PDF_EXTENSION_RE.test(file.name));
+		if (valid.length === 0) {
+			error = "Please select one or more PDF files";
+			return;
+		}
+		error = "";
+		clearProcessed();
+		sourcePdfs = [
+			...sourcePdfs,
+			...valid.map(file => ({ id: `pdf-${crypto.randomUUID()}`, file })),
+		];
+	}
+
+	function handleSelect(event: Event) {
+		const input = event.target as HTMLInputElement;
+		addFiles(input.files ? [...input.files] : []);
+		input.value = "";
+	}
+
+	function handleDrop(event: DragEvent) {
+		event.preventDefault();
+		addFiles(event.dataTransfer?.files ? [...event.dataTransfer.files] : []);
+	}
+
+	function removeFile(id: string) {
+		sourcePdfs = sourcePdfs.filter(item => item.id !== id);
+		clearProcessed();
+	}
+
+	async function processPdfs() {
+		if (sourcePdfs.length === 0)
+			return;
+
+		processing = true;
+		processedCount = 0;
+		error = "";
+		statusText = "";
+		clearProcessed();
+
+		try {
+			const next: ProcessedPdf[] = [];
+			for (let index = 0; index < sourcePdfs.length; index += 1) {
+				const source = sourcePdfs[index];
+				statusText = `Processing ${source.file.name}...`;
+				const bytes = await source.file.arrayBuffer();
+				const result = mode === "rasterize"
+					? await rasterizePdf(bytes, { dpi, quality })
+					: await downsamplePdf(bytes, { imageDpi, imageQuality });
+				const blob = new Blob([new Uint8Array(result)], { type: "application/pdf" });
+				next.push({
+					fileName: `${baseName(source.file.name)}_compressed.pdf`,
+					blob,
+					originalSize: source.file.size,
+				});
+				processedCount = index + 1;
+			}
+			processedPdfs = next;
+			statusText = "";
+		}
+		catch (err) {
+			error = (err as Error).message || "Failed to compress PDF";
+			clearProcessed();
+		}
+		finally {
+			processing = false;
+		}
+	}
+
+	function downloadBlob(blob: Blob, name: string) {
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = name;
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
+	}
+
+	async function downloadZip() {
+		if (processedPdfs.length === 0 || processing)
+			return;
+		processing = true;
+		error = "";
+		try {
+			const zip = new JSZip();
+			processedPdfs.forEach((item) => {
+				zip.file(item.fileName, item.blob);
+			});
+			const blob = await zip.generateAsync({ type: "blob" });
+			downloadBlob(blob, "compressed_pdfs.zip");
+		}
+		catch (err) {
+			error = (err as Error).message || "Failed to create zip";
+		}
+		finally {
+			processing = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>PDF Compressor</title>
+</svelte:head>
+
+<main class="mx-auto max-w-4xl px-4 py-8">
+	<a href={resolvePath("/")} class="text-primary mb-6 inline-block text-sm hover:underline">← Back to Tools</a>
+
+	<h1 class="mb-1 flex items-center gap-2 text-3xl font-bold tracking-tight">
+		<FileArchive class="text-primary size-7" />
+		PDF Compressor
+	</h1>
+	<p class="text-muted-foreground mb-8">Shrink PDF file sizes right in your browser.</p>
+
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Upload PDFs</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<label
+				class="border-input hover:border-ring hover:bg-accent bg-muted/40 flex cursor-pointer flex-col items-center gap-2 rounded-xl border-2 border-dashed p-8 text-center transition-colors"
+				ondrop={handleDrop}
+				ondragover={handleDragOver}
+			>
+				<Upload class="text-muted-foreground size-9" />
+				<p class="font-medium">Drag & drop PDF files</p>
+				<p class="text-muted-foreground text-sm">or click to browse</p>
+				{#if sourcePdfs.length > 0}
+					<p class="text-muted-foreground text-sm">{sourcePdfs.length} PDF{sourcePdfs.length === 1 ? "" : "s"} loaded</p>
+				{/if}
+				<input type="file" accept="application/pdf,.pdf" multiple onchange={handleSelect} hidden />
+			</label>
+			{#if sourcePdfs.length > 0}
+				<div class="mt-3 space-y-2">
+					{#each sourcePdfs as item (item.id)}
+						<div class="bg-muted flex items-center justify-between gap-2 rounded-lg border px-3 py-2">
+							<span class="truncate text-sm" title={item.file.name}>{item.file.name}</span>
+							<div class="flex shrink-0 items-center gap-2">
+								<span class="text-muted-foreground text-xs">{formatBytes(item.file.size)}</span>
+								<Button variant="ghost" size="icon" class="size-7" onclick={() => removeFile(item.id)} aria-label="Remove">
+									<Trash2 class="size-3.5" />
+								</Button>
+							</div>
+						</div>
+					{/each}
+					<Button variant="outline" size="sm" onclick={clearAll}>Clear All</Button>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title>Compression Settings</Card.Title>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			<div class="grid gap-1.5">
+				<Label>Mode</Label>
+				<div class="bg-muted inline-flex flex-wrap gap-1 rounded-lg p-1">
+					<Button variant={mode === "downsample" ? "default" : "ghost"} size="sm" onclick={() => (mode = "downsample")}>Downsample images (keep text)</Button>
+					<Button variant={mode === "rasterize" ? "default" : "ghost"} size="sm" onclick={() => (mode = "rasterize")}>Aggressive (rasterize)</Button>
+				</div>
+			</div>
+
+			{#if mode === "downsample"}
+				<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+					<div class="grid gap-1.5">
+						<Label for="imageDpi">Target image resolution</Label>
+						<Select id="imageDpi" bind:value={imageDpi}>
+							{#each imageDpiOptions as option (option.value)}
+								<option value={option.value}>{option.label}</option>
+							{/each}
+						</Select>
+					</div>
+					<div class="grid gap-1.5">
+						<Label for="imageQuality">JPEG Quality ({imageQuality}%)</Label>
+						<div class="flex h-9 items-center"><Slider type="single" min={1} max={100} bind:value={imageQuality} /></div>
+					</div>
+				</div>
+				<p class="text-muted-foreground text-sm">
+					Recompresses embedded JPEG photos to a target DPI (based on where each image sits on the page) while leaving text and vectors selectable. Images it can't safely re-encode (CMYK, lossless, masked) or place are left at full resolution and only re-compressed, so gains depend on the PDF.
+				</p>
+			{:else}
+				<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+					<div class="grid gap-1.5">
+						<Label for="dpi">Resolution (DPI)</Label>
+						<Select id="dpi" bind:value={dpi}>
+							{#each dpiOptions as option (option.value)}
+								<option value={option.value}>{option.label}</option>
+							{/each}
+						</Select>
+					</div>
+					<div class="grid gap-1.5">
+						<Label for="quality">JPEG Quality ({quality}%)</Label>
+						<div class="flex h-9 items-center"><Slider type="single" min={1} max={100} bind:value={quality} /></div>
+					</div>
+				</div>
+				<p class="text-muted-foreground text-sm">
+					Each page is re-rendered as a JPEG image and rebuilt into a new PDF. Big, reliable size reductions — but text becomes part of the image and is no longer selectable or searchable.
+				</p>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	{#if error}
+		<div class="border-destructive/40 bg-destructive/10 text-destructive mb-4 rounded-lg border px-4 py-3 text-sm">⚠️ {error}</div>
+	{/if}
+
+	{#if sourcePdfs.length > 0}
+		<div class="mb-6 text-center">
+			<Button size="lg" onclick={processPdfs} disabled={!canProcess}>
+				{#if processing}
+					<LoaderCircle class="size-4 animate-spin" />
+					Compressing {processedCount}/{sourcePdfs.length}...
+				{:else}
+					Compress {sourcePdfs.length} PDF{sourcePdfs.length === 1 ? "" : "s"}
+				{/if}
+			</Button>
+			{#if processing && statusText}
+				<p class="text-muted-foreground mt-2 text-sm">{statusText}</p>
+			{/if}
+		</div>
+	{/if}
+
+	{#if hasResults}
+		<Card.Root class="mb-6" id="results">
+			<Card.Header class="flex-row items-center justify-between space-y-0">
+				<Card.Title>Results</Card.Title>
+				{#if processedPdfs.length > 1}
+					<Button onclick={downloadZip} disabled={processing}>
+						<Package class="size-4" />
+						Download ZIP
+					</Button>
+				{/if}
+			</Card.Header>
+			<Card.Content class="space-y-4">
+				<div class="grid grid-cols-3 gap-3">
+					<div class="bg-muted flex flex-col gap-1 rounded-lg border p-3">
+						<span class="text-muted-foreground text-xs">Original</span>
+						<strong>{formatBytes(originalTotalBytes)}</strong>
+					</div>
+					<div class="bg-muted flex flex-col gap-1 rounded-lg border p-3">
+						<span class="text-muted-foreground text-xs">Compressed</span>
+						<strong>{formatBytes(processedTotalBytes)}</strong>
+					</div>
+					<div class="bg-muted flex flex-col gap-1 rounded-lg border p-3">
+						<span class="text-muted-foreground text-xs">Change</span>
+						<strong class={sizeDeltaPercent > 0 ? "text-destructive" : "text-emerald-600 dark:text-emerald-400"}>
+							{sizeDeltaPercent > 0 ? "+" : ""}{sizeDeltaPercent.toFixed(1)}%
+						</strong>
+					</div>
+				</div>
+
+				<div class="space-y-2">
+					{#each processedPdfs as item (item.fileName)}
+						{@const delta = item.originalSize > 0 ? ((item.blob.size - item.originalSize) / item.originalSize) * 100 : 0}
+						<div class="flex items-center justify-between gap-2 rounded-lg border px-3 py-2">
+							<span class="truncate text-sm" title={item.fileName}>{item.fileName}</span>
+							<div class="flex shrink-0 items-center gap-3 text-xs">
+								<span class="text-muted-foreground">{formatBytes(item.originalSize)} → {formatBytes(item.blob.size)}</span>
+								<span class={cn("font-medium", delta > 0 ? "text-destructive" : "text-emerald-600 dark:text-emerald-400")}>
+									{delta > 0 ? "+" : ""}{delta.toFixed(1)}%
+								</span>
+								<button type="button" class="text-primary hover:underline" onclick={() => downloadBlob(item.blob, item.fileName)}>Download</button>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+
+	<footer class="text-muted-foreground text-center text-sm">
+		<p>✨ Runs in your browser • No uploads required</p>
+	</footer>
+</main>


### PR DESCRIPTION
Adds two new client-side tools to the directory, matching existing conventions (Svelte 5 runes, shadcn-svelte UI, no uploads, ZIP export).

## Image Cropper (`/tools/image-cropper`)
- Batch crop to a shared aspect ratio (presets + custom), centre-cropped by default
- 3×3 crop-alignment grid to position the default crop
- "Customise Crop Positions" button opens the editor on the first image
- Interactive editor: drag to move, corner handles to resize/shrink, per-image alignment grid
- Arrow-key + prev/next navigation between images in the modal
- Optional exact output pixel dimensions (drives the ratio when enabled)
- JPEG / PNG / WebP output + quality

## PDF Compressor (`/tools/pdf-compressor`)
- **Downsample images (keep text)** — default. Recompresses embedded JPEG (`DCTDecode`) images to a target DPI while leaving text and vectors selectable. DPI is derived from each image's on-page placement via a small content-stream interpreter (tracks the CTM through `q`/`Q`/`cm`, recurses into form XObjects, maps resource name → object ref directly). Images it can't safely decode or place (CMYK, `FlateDecode`, masked, multi-filter) fall back to quality-only recompression.
- **Aggressive (rasterize)** — renders each page to JPEG at a chosen DPI/quality for the biggest reductions; text becomes part of the image.
- All PDF logic lives in `src/lib/pdf-compress.ts` to keep the component lean.

## Notes
- New dependency: `pdfjs-dist@6.1.200` (used by the rasterize mode and content-stream analysis).
- `pnpm check`, `pnpm lint`, and `pnpm build` all pass.
- Not yet exercised against real files in a running dev server.
