### PR TITLE
fix: regenerate pnpm-lock.yaml to repair broken postcss entries

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1114,26 +1114,6 @@ packages:
     resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   '@vitest/eslint-plugin@1.6.25':
     resolution: {integrity: sha512-ylqFL2TYRgtTewl5Kr2NCL3fnLOMNo91XEyniB4tA1zlnZs0GbrNj6ER6ldR9J3r5RSL0dQ7EeMUiXsbfHrvpg==}
     engines: {node: '>=18'}
@@ -3578,26 +3558,6 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   '@vitest/eslint-plugin@1.6.25(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
@@ -3982,9 +3942,9 @@ snapshots:
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
-      postcss: 8.5.25
-      postcss-load-config: 3.1.4(postcss@8.5.25)
-      postcss-safe-parser: 7.0.1(postcss@8.5.25)
+      postcss: 8.5.26
+      postcss-load-config: 3.1.4(postcss@8.5.26)
+      postcss-safe-parser: 7.0.1(postcss@8.5.26)
       semver: 7.8.5
       svelte-eslint-parser: 1.8.0(svelte@5.56.8(@typescript-eslint/types@8.65.0))
     optionalDependencies:
@@ -4956,16 +4916,16 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  postcss-load-config@3.1.4(postcss@8.5.25):
+  postcss-load-config@3.1.4(postcss@8.5.26):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.3
     optionalDependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
 
-  postcss-safe-parser@7.0.1(postcss@8.5.25):
+  postcss-safe-parser@7.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.25
+      postcss: 8.5.26
 
   postcss-scss@4.0.9(postcss@8.5.16):
     dependencies:
@@ -5311,7 +5271,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.25
+      postcss: 8.5.26
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Problem

`main` is currently unbuildable. The Cloudflare Pages build fails at the install step:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'postcss@8.5.25' in pnpm-lock.yaml
This issue is probably caused by a badly resolved merge conflict.
```

## Cause

The grouped dependency bump in #97 moved postcss from **8.5.25 to 8.5.26** in the lockfile's `packages:` and `snapshots:` definitions, but only partially rewrote the references to it. The lockfile ended up internally inconsistent:

**Defined:** `postcss@8.5.16`, `postcss@8.5.26`

**Still pointing at 8.5.25** — eight references:

| Line | Reference |
|---|---|
| 3985 | `postcss: 8.5.25` (under `eslint-plugin-svelte@3.22.0`) |
| 3986 | `postcss-load-config: 3.1.4(postcss@8.5.25)` |
| 3987 | `postcss-safe-parser: 7.0.1(postcss@8.5.25)` |
| 4959 | `postcss-load-config@3.1.4(postcss@8.5.25):` — peer suffix in the key |
| 4966 | `postcss-safe-parser@7.0.1(postcss@8.5.25):` — peer suffix in the key |
| 4964, 4968, 5314 | `postcss: 8.5.25` |

`postcss` is not a direct dependency, so nothing in `package.json` looks wrong — the damage is confined to the peer-suffixed snapshot keys, which is why it slipped through.

## Fix

Regenerated with `pnpm install --no-frozen-lockfile`.

- stray `8.5.25` references: **8 → 0**
- `lockfileVersion` unchanged at `9.0`, so the older pnpm used in CI still reads it
- **no dependency versions change** — the diff is the postcss references and some blank lines

## Verification

Reproduced the CI failure locally against `origin/main`, applied the fix, then re-ran both steps of the Pages build command:

- `pnpm install --frozen-lockfile` — passes
- `pnpm build` — passes, writes to `build/` as configured

## Follow-ups, not in this PR

- **`dependabot/npm_and_yarn/npm-dependencies-d9a3dfd157` carries the same corruption**, with 11 stray references. It needs rebasing on this fix and its lockfile regenerated before it can merge.
- There is no `packageManager` field in `package.json`, so the pnpm version used by Pages floats with Cloudflare's default (currently 10.11.1) while local development is on a newer release. Pinning it would remove a class of lockfile skew, though it is not what caused this failure.
